### PR TITLE
Use tuples instead of arrays as activation function return types

### DIFF
--- a/src/shainet/basic/functions.cr
+++ b/src/shainet/basic/functions.cr
@@ -1,33 +1,35 @@
 module SHAInet
+  alias ActivationFunction = Proc(GenNum, Tuple(Float64, Float64))
+
   # As Procs
 
-  def self.none : Proc(GenNum, Array(Float64)) # Output range -inf..inf)
-    ->(value : GenNum) { [value.to_f64, 1.0.to_f64] }
+  def self.none : ActivationFunction # Output range -inf..inf)
+    ->(value : GenNum) { {value.to_f64, 1.0_f64} }
   end
 
-  def self.sigmoid : Proc(GenNum, Array(Float64)) # Output range (0..1)
-    ->(value : GenNum) { [_sigmoid(value), _sigmoid_prime(value)] }
+  def self.sigmoid : ActivationFunction # Output range (0..1)
+    ->(value : GenNum) { {_sigmoid(value), _sigmoid_prime(value)} }
   end
 
-  def self.bp_sigmoid : Proc(GenNum, Array(Float64)) # Output range (-1..1)
-    ->(value : GenNum) { [_bp_sigmoid(value), _bp_sigmoid_prime(value)] }
+  def self.bp_sigmoid : ActivationFunction # Output range (-1..1)
+    ->(value : GenNum) { {_bp_sigmoid(value), _bp_sigmoid_prime(value)} }
   end
 
-  def self.log_sigmoid : Proc(GenNum, Array(Float64)) # Output range (0..1)
-    ->(value : GenNum) { [_log_sigmoid(value), _log_sigmoid_prime(value)] }
+  def self.log_sigmoid : ActivationFunction # Output range (0..1)
+    ->(value : GenNum) { {_log_sigmoid(value), _log_sigmoid_prime(value)} }
   end
 
-  def self.tanh : Proc(GenNum, Array(Float64)) # Output range (-1..1)
-    ->(value : GenNum) { [_tanh(value), _tanh_prime(value)] }
+  def self.tanh : ActivationFunction # Output range (-1..1)
+    ->(value : GenNum) { {_tanh(value), _tanh_prime(value)} }
   end
 
-  def self.relu : Proc(GenNum, Array(Float64)) # Output range (0..inf)
-    ->(value : GenNum) { [_relu(value), _relu_prime(value)] }
+  def self.relu : ActivationFunction # Output range (0..inf)
+    ->(value : GenNum) { {_relu(value), _relu_prime(value)} }
   end
 
-  def self.l_relu : Proc(GenNum, Array(Float64)) # Output range (-inf..inf)
+  def self.l_relu : ActivationFunction # Output range (-inf..inf)
     # (value : GenNum, slope : Float64 = 0.01) : Float64
-    ->(value : GenNum) { [_l_relu(value), _l_relu_prime(value)] }
+    ->(value : GenNum) { {_l_relu(value), _l_relu_prime(value)} }
   end
 
   # # Activation functions # #

--- a/src/shainet/basic/layer.cr
+++ b/src/shainet/basic/layer.cr
@@ -3,7 +3,7 @@ module SHAInet
     property :n_type, :neurons
     getter :activation_function
 
-    def initialize(@n_type : String, l_size : Int32, @activation_function : Proc(GenNum, Array(Float64)) = SHAInet.sigmoid, @logger : Logger = Logger.new(STDOUT))
+    def initialize(@n_type : String, l_size : Int32, @activation_function : ActivationFunction = SHAInet.sigmoid, @logger : Logger = Logger.new(STDOUT))
       @neurons = Array(Neuron).new
       # Populate layer with neurons
       l_size.times do

--- a/src/shainet/basic/network.cr
+++ b/src/shainet/basic/network.cr
@@ -60,7 +60,7 @@ module SHAInet
     # l_type is: :input, :hidden or :output
     # l_size = how many neurons in the layer
     # n_type = advanced option for different neuron types
-    def add_layer(l_type : Symbol | String, l_size : Int32, n_type : Symbol | String = "memory", activation_function : Proc(GenNum, Array(Float64)) = SHAInet.sigmoid)
+    def add_layer(l_type : Symbol | String, l_size : Int32, n_type : Symbol | String = "memory", activation_function : ActivationFunction = SHAInet.sigmoid)
       layer = Layer.new(n_type.to_s, l_size, activation_function, @logger)
       layer.neurons.each { |neuron| @all_neurons << neuron } # To easily access neurons later
 
@@ -141,7 +141,7 @@ module SHAInet
     def connect_ltl(source : Layer, destination : Layer, connection_type : Symbol | String)
       raise NeuralNetInitalizationError.new("Error initilizing network, must choose correct connection type.") if CONNECTION_TYPES.any? { |x| x == connection_type.to_s } == false
       case connection_type.to_s
-        # Connect each neuron from source layer to all neurons in destination layer
+      # Connect each neuron from source layer to all neurons in destination layer
       when "full"
         source.neurons.each do |neuron1|        # Source neuron
           destination.neurons.each do |neuron2| # Destination neuron
@@ -284,11 +284,11 @@ module SHAInet
 
     # Online train, updates weights/biases after each data point (stochastic gradient descent)
     def train(data : Array(Array(Array(GenNum))), # Input structure: data = [[Input = [] of Float64],[Expected result = [] of Float64]]
-      training_type : Symbol | String,    # Type of training: :sgdm, :rprop, :adam
-      cost_function : Symbol | String,    # one of COST_FUNCTIONS described at the top of the file
-      epochs : Int32,                     # a criteria of when to stop the training
-      error_threshold : Float64,          # a criteria of when to stop the training
-      log_each : Int32 = 1000)            # determines what is the step for error printout
+              training_type : Symbol | String,    # Type of training: :sgdm, :rprop, :adam
+              cost_function : Symbol | String,    # one of COST_FUNCTIONS described at the top of the file
+              epochs : Int32,                     # a criteria of when to stop the training
+              error_threshold : Float64,          # a criteria of when to stop the training
+              log_each : Int32 = 1000)            # determines what is the step for error printout
 
       verify_data(data)
       @logger.info("Training started")
@@ -336,12 +336,12 @@ module SHAInet
 
     # Batch train, updates weights/biases using a gradient sum from all data points in the batch (using gradient descent)
     def train_batch(data : Array(Array(Array(GenNum))) | SHAInet::TrainingData, # Input structure: data = [[Input = [] of Float64],[Expected result = [] of Float64]]
-      training_type : Symbol | String,    # Type of training: :sgdm, :rprop, :adam
-      cost_function : Symbol | String,    # one of COST_FUNCTIONS described at the top of the file
-      epochs : Int32,                     # a criteria of when to stop the training
-      error_threshold : Float64,          # a criteria of when to stop the training
-      log_each : Int32 = 1000,            # determines what is the step for error printout
-      mini_batch_size : Int32 | Nil = nil)
+                    training_type : Symbol | String,                            # Type of training: :sgdm, :rprop, :adam
+                    cost_function : Symbol | String,                            # one of COST_FUNCTIONS described at the top of the file
+                    epochs : Int32,                                             # a criteria of when to stop the training
+                    error_threshold : Float64,                                  # a criteria of when to stop the training
+                    log_each : Int32 = 1000,                                    # determines what is the step for error printout
+                    mini_batch_size : Int32 | Nil = nil)
       # This methods accepts data as either a SHAInet::TrainingData object, or as an Array(Array(Array(GenNum)).
       # In the case of SHAInet::TrainingData, we convert it to an Array(Array(Array(GenNum)) by calling #data on it.
       raw_data = data.is_a?(SHAInet::TrainingData) ? data.data : data
@@ -421,7 +421,7 @@ module SHAInet
         end
 
         case learn_type.to_s
-          # Update weights based on the gradients and delta rule (including momentum)
+        # Update weights based on the gradients and delta rule (including momentum)
         when "sgdm"
           delta_weight = (-1)*@learning_rate*synapse.gradient + @momentum*(synapse.weight - synapse.prev_weight)
           synapse.weight += delta_weight
@@ -474,7 +474,7 @@ module SHAInet
         end
 
         case learn_type.to_s
-          # Update biases based on the gradients and delta rule (including momentum)
+        # Update biases based on the gradients and delta rule (including momentum)
         when "sgdm"
           delta_bias = (-1)*@learning_rate*(neuron.gradient) + @momentum*(neuron.bias - neuron.prev_bias)
           neuron.bias += delta_bias
@@ -648,10 +648,8 @@ module SHAInet
           incorrect += 1
         end
       end
-      @logger.info("Predicted #{correct} out of #{correct + incorrect} - #{(correct.to_f/(correct+incorrect).to_f)*100}%")
-      correct.to_f/(correct+incorrect).to_f
+      @logger.info("Predicted #{correct} out of #{correct + incorrect} - #{(correct.to_f/(correct + incorrect).to_f)*100}%")
+      correct.to_f/(correct + incorrect).to_f
     end
-
-
   end
 end

--- a/src/shainet/basic/neuron.cr
+++ b/src/shainet/basic/neuron.cr
@@ -39,7 +39,7 @@ module SHAInet
     # This is the forward propogation
     # Allows the neuron to absorb the activation from its' own input neurons through the synapses
     # Then, it sums the information and an activation function is applied to normalize the data
-    def activate(activation_function : Proc(GenNum, Array(Float64)) = SHAInet.sigmoid) : Float64
+    def activate(activation_function : ActivationFunction = SHAInet.sigmoid) : Float64
       new_memory = Array(Float64).new
       @synapses_in.each do |synapse| # Claclulate activation from each incoming neuron with applied weights, returns Array(Float64)
         new_memory << synapse.propagate_forward

--- a/src/shainet/cnn/cnn.cr
+++ b/src/shainet/cnn/cnn.cr
@@ -56,7 +56,7 @@ module SHAInet
                  window_size : Int32,
                  stride : Int32,
                  padding : Int32,
-                 activation_function : Proc(GenNum, Array(Float64)) = SHAInet.none)
+                 activation_function : ActivationFunction = SHAInet.none)
       @layers << ConvLayer.new(master = self, @layers.last, filters_num, window_size, stride, padding, activation_function)
     end
 
@@ -72,7 +72,7 @@ module SHAInet
       @layers << DropoutLayer.new(@layers.last, drop_percent)
     end
 
-    def add_fconnect(l_size : Int32, activation_function : Proc(GenNum, Array(Float64)) = SHAInet.none)
+    def add_fconnect(l_size : Int32, activation_function : ActivationFunction = SHAInet.none)
       @layers << FullyConnectedLayer.new(master = self, @layers.last, l_size, activation_function)
     end
 

--- a/src/shainet/cnn/conv_layer.cr
+++ b/src/shainet/cnn/conv_layer.cr
@@ -3,7 +3,7 @@ require "logger"
 module SHAInet
   class ConvLayer
     getter master_network : CNN, prev_layer : CNNLayer | ConvLayer, filters : Array(Filter)
-    getter window_size : Int32, stride : Int32, padding : Int32, activation_function : Proc(GenNum, Array(Float64))
+    getter window_size : Int32, stride : Int32, padding : Int32, activation_function : ActivationFunction
 
     def initialize(@master_network : CNN,
                    @prev_layer : ConvLayer | CNNLayer,
@@ -11,7 +11,7 @@ module SHAInet
                    @window_size : Int32 = 1,
                    @stride : Int32 = 1,
                    @padding : Int32 = 0,
-                   @activation_function : Proc(GenNum, Array(Float64)) = SHAInet.none,
+                   @activation_function : ActivationFunction = SHAInet.none,
                    @logger : Logger = Logger.new(STDOUT))
       #
       raise CNNInitializationError.new("ConvLayer must have at least one filter") if filters_num < 1

--- a/src/shainet/cnn/fc_layer.cr
+++ b/src/shainet/cnn/fc_layer.cr
@@ -8,7 +8,7 @@ module SHAInet
     def initialize(@master_network : CNN,
                    @prev_layer : CNNLayer | ConvLayer,
                    l_size : Int32,
-                   @activation_function : Proc(GenNum, Array(Float64)) = SHAInet.none,
+                   @activation_function : ActivationFunction = SHAInet.none,
                    @logger : Logger = Logger.new(STDOUT))
       #
       # since this is similar to a classic layer, we store all neurons in a single array

--- a/src/shainet/cnn/filter.cr
+++ b/src/shainet/cnn/filter.cr
@@ -2,7 +2,7 @@ require "logger"
 
 module SHAInet
   class Filter
-    getter input_surface : Array(Int32), window_size : Int32, stride : Int32, padding : Int32, activation_function : Proc(GenNum, Array(Float64))
+    getter input_surface : Array(Int32), window_size : Int32, stride : Int32, padding : Int32, activation_function : ActivationFunction
     property neurons : Array(Array(Neuron)), synapses : Array(Array(Array(CnnSynapse)))
     property bias : Float64, prev_bias : Float64, bias_grad : Float64, bias_grad_sum : Float64
     property prev_bias_grad : Float64, prev_delta : Float64, prev_delta_b : Float64
@@ -12,7 +12,7 @@ module SHAInet
                    @padding : Int32 = 0,
                    @window_size : Int32 = 1,
                    @stride : Int32 = 1,
-                   @activation_function : Proc(GenNum, Array(Float64)) = SHAInet.none)
+                   @activation_function : ActivationFunction = SHAInet.none)
       #
       @neurons = Array(Array(Neuron)).new(input_surface[1]) {
         Array(Neuron).new(input_surface[0]) { Neuron.new("memory") }


### PR DESCRIPTION
This is a tiny optimization.

The formatter was automatically run and changed some lines, I expect you don't mind.