### PR TITLE
Optimize Neuron#activate method

### DIFF
--- a/src/shainet/basic/neuron.cr
+++ b/src/shainet/basic/neuron.cr
@@ -40,12 +40,11 @@ module SHAInet
     # Allows the neuron to absorb the activation from its' own input neurons through the synapses
     # Then, it sums the information and an activation function is applied to normalize the data
     def activate(activation_function : ActivationFunction = SHAInet.sigmoid) : Float64
-      new_memory = Array(Float64).new
-      @synapses_in.each do |synapse| # Claclulate activation from each incoming neuron with applied weights, returns Array(Float64)
-        new_memory << synapse.propagate_forward
+      sum = 0_f64
+      @synapses_in.each do |synapse| # Sum activation from each incoming neuron with applied weights
+        sum += synapse.propagate_forward
       end
-      @input_sum = new_memory.reduce { |acc, i| acc + i } # Sum all the information from input neurons, returns Float64
-      @input_sum += @bias                                 # Add neuron bias (activation threshold)
+      @input_sum = sum + @bias # Add neuron bias (activation threshold)
       @activation, @sigma_prime = activation_function.call(@input_sum)
     end
 


### PR DESCRIPTION
Avoid creating an intermediate array.

Running a benchmark shows this optimization converts into approximatelly 10% in performance gain on final `Network#run` method.

```
$ crystal run --release bench.cr 
original   1.86M (536.63ns) (± 4.24%)  1.13× slower
modified   2.11M (474.37ns) (± 4.32%)       fastest
```