### PR TITLE
Fix indentation in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ clean:
 
 # GPU benchmark target (optional)
 benchmark: $(CUDA_LIB)
-        @echo "Running transformer training benchmark..."
-        @LD_LIBRARY_PATH=.:$$LD_LIBRARY_PATH crystal run benchmarks/transformer_training_benchmark.cr
+	@echo "Running transformer training benchmark..."
+	@LD_LIBRARY_PATH=.:$$LD_LIBRARY_PATH crystal run benchmarks/transformer_training_benchmark.cr
 
 .DEFAULT_GOAL := help


### PR DESCRIPTION
Fix the following error when running `make`

```console
Makefile:90: *** missing separator.  (Did you mean to use a TAB instead of 8 spaces?)  Stop.
```

Replaced 8 spaces with a TAB.