### PR TITLE
feat: GPU-accelerated LLaMA inference + BPE encoder fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,18 @@ To build kernels manually:
 ./build_cuda_kernels.sh
 ```
 
+#### RTX 30/40 Series (Ampere/Ada) Note
+
+These GPUs use TF32 tensor cores by default for FP32 matrix multiply, which
+reduces mantissa precision from 23 to 10 bits. For LLM inference this can cause
+non-deterministic token generation. SHAInet sets
+`CUBLAS_MATH_DISALLOW_REDUCED_PRECISION_REDUCTION` automatically, but for full
+FP32 precision also set:
+
+```bash
+export NVIDIA_TF32_OVERRIDE=0
+```
+
 ### Device management
 
 Layers such as `LayerNorm` allocate workspace matrices on the first forward pass

--- a/examples/llama_chat.cr
+++ b/examples/llama_chat.cr
@@ -164,7 +164,7 @@ loop do
     vocab_size = logits.cols
     scored = Array(Tuple(Int32, Float64)).new(vocab_size)
     vocab_size.times { |j| scored << {j, logits[0, j] / temperature} }
-    scored.sort_by! { |_, v| v.nan? ? -Float64::INFINITY : -v }
+    scored.sort_by! { |_, v| v.nan? ? Float64::INFINITY : -v }
     top_k = scored.first(40)
 
     # Softmax over top-k

--- a/examples/llama_chat.cr
+++ b/examples/llama_chat.cr
@@ -128,6 +128,7 @@ loop do
   generated_ids = Array(Int32).new
   temperature = 0.6_f64
   repetition_penalty = 1.2_f64
+  gen_start = Time.instant
 
   max_tokens.times do
     # Get logits from last position
@@ -197,6 +198,9 @@ loop do
     net.transformer_layers.each { |l| x_new = l.as(SHAInet::LlamaBlock).forward_cached(x_new) }
     x = x_new
   end
-  puts ""
+  gen_elapsed = (Time.instant - gen_start).total_seconds
+  if generated_ids.size > 0
+    STDERR.puts "(#{generated_ids.size} tokens, #{(generated_ids.size / gen_elapsed).round(1)} tok/s)"
+  end
   puts ""
 end

--- a/examples/llama_chat.cr
+++ b/examples/llama_chat.cr
@@ -28,7 +28,7 @@ def download_model(model_dir : String, repo : String)
 end
 
 arg = ARGV[0]?
-max_tokens = (ARGV[1]? || "60").to_i
+max_tokens = (ARGV[1]? || "256").to_i
 
 # Resolve the model directory:
 #  - existing local directory       -> use as-is
@@ -48,9 +48,9 @@ model_dir =
 
 # --- Load model ---
 STDERR.puts "Loading model from #{model_dir}..."
-t = Time.monotonic
+t = Time.instant
 net = SHAInet::HFLoader.load_llama(model_dir)
-STDERR.puts "Model loaded in #{(Time.monotonic - t).total_seconds.round(1)}s"
+STDERR.puts "Model loaded in #{(Time.instant - t).total_seconds.round(1)}s"
 STDERR.puts "  Layers: #{net.transformer_layers.size}, d_model: #{net.transformer_layers.first.as(SHAInet::LlamaBlock).d_model}"
 
 # --- Load tokenizer ---
@@ -61,13 +61,14 @@ STDERR.puts ""
 # --- Cached generation setup ---
 emb = net.hidden_layers.find(&.is_a?(SHAInet::EmbeddingLayer)).as(SHAInet::EmbeddingLayer)
 fn = net.final_norm.not_nil!
-w = net.output_layers.first.weights.as(SHAInet::SimpleMatrix)
+w : SHAInet::SimpleMatrix | SHAInet::CudaMatrix = net.output_layers.first.weights.as(SHAInet::SimpleMatrix)
 d_model = net.transformer_layers.first.as(SHAInet::LlamaBlock).d_model
 
 # Move weights to GPU if available
 if SHAInet::CUDA.fully_available?
   STDERR.puts "Moving to GPU..."
   net.transformer_layers.each { |l| l.as(SHAInet::LlamaBlock).to_gpu! }
+  w = w.as(SHAInet::SimpleMatrix).to_cuda.tap(&.mark_device_dirty!)
   STDERR.puts "GPU ready!"
 end
 
@@ -133,7 +134,24 @@ loop do
     last = SHAInet::SimpleMatrix.new(1, d_model)
     d_model.times { |j| last[0, j] = x[x.rows - 1, j] }
     normed = fn.forward(last)
-    logits = normed * w
+    logits = if w.is_a?(SHAInet::CudaMatrix)
+               w_cuda = w.as(SHAInet::CudaMatrix)
+               n_gpu = SHAInet::CudaMatrix.new(1, normed.cols)
+               n_gpu.raw_data.to_unsafe.copy_from(normed.data.to_unsafe, normed.cols)
+               n_gpu.sync_to_device!("lm_head")
+               r = SHAInet::CudaMatrix.new(1, w_cuda.cols)
+               h = SHAInet::CUDA.create_handle
+               SHAInet::CUDA.gemm(h, w_cuda.device_ptr.not_nil!, n_gpu.device_ptr.not_nil!, r.device_ptr.not_nil!,
+                 w_cuda.cols, 1, w_cuda.rows, w_cuda.cols, normed.cols, w_cuda.cols)
+               SHAInet::CUDA.destroy_handle(h)
+               r.mark_device_dirty!
+               r.sync_from_device!("lm_head")
+               out = SHAInet::SimpleMatrix.new(1, r.cols)
+               out.data.to_unsafe.copy_from(r.raw_data.to_unsafe, r.cols)
+               out
+             else
+               normed * w.as(SHAInet::SimpleMatrix)
+             end
 
     # Apply repetition penalty to recently generated tokens
     generated_ids.last(20).each do |prev_id|
@@ -145,7 +163,7 @@ loop do
     vocab_size = logits.cols
     scored = Array(Tuple(Int32, Float64)).new(vocab_size)
     vocab_size.times { |j| scored << {j, logits[0, j] / temperature} }
-    scored.sort_by! { |_, v| -v }
+    scored.sort_by! { |_, v| v.nan? ? -Float64::INFINITY : -v }
     top_k = scored.first(40)
 
     # Softmax over top-k
@@ -168,6 +186,7 @@ loop do
 
     # Stop on end-of-turn / end-of-text
     break if best_id == eot_id || best_id == eos_id || best_id < 0
+    break unless logits[0, best_id].finite? # bail on NaN logits
     generated_ids << best_id
     print tokenizer.decode([best_id])
     STDOUT.flush

--- a/examples/prof.cr
+++ b/examples/prof.cr
@@ -1,0 +1,37 @@
+require "../src/shainet"
+
+model_dir = ARGV[0]? || "/tmp/llama32"
+tok = SHAInet::BPETokenizer.from_hf(File.join(model_dir, "tokenizer.json"))
+net = SHAInet::HFLoader.load_llama(model_dir)
+net.transformer_layers.each { |l| l.as(SHAInet::LlamaBlock).to_gpu! }
+emb = net.hidden_layers.find(&.is_a?(SHAInet::EmbeddingLayer)).as(SHAInet::EmbeddingLayer)
+fn = net.final_norm.not_nil!
+w_sm = net.output_layers.first.weights.as(SHAInet::SimpleMatrix)
+w = w_sm.to_cuda.tap(&.mark_device_dirty!)
+d = emb.embeddings.cols
+
+ids = [128000] + tok.encode("The capital of France is")
+net.transformer_layers.each { |l| l.as(SHAInet::LlamaBlock).clear_cache! }
+x = SHAInet::SimpleMatrix.new(ids.size, d)
+ids.each_with_index { |id, i| d.times { |j| x[i, j] = emb.embeddings[id, j] } }
+net.transformer_layers.each { |l| x = l.as(SHAInet::LlamaBlock).forward_cached(x) }
+
+n = 10
+t = Time.instant
+n.times do
+  last = SHAInet::SimpleMatrix.new(1, d)
+  d.times { |j| last[0, j] = x[x.rows - 1, j] }
+  normed = fn.forward(last)
+  n_gpu = SHAInet::CudaMatrix.new(normed.rows, normed.cols)
+  n_gpu.raw_data.to_unsafe.copy_from(normed.data.to_unsafe, normed.rows * normed.cols)
+  n_gpu.sync_to_device!("lm_head")
+  logits_gpu = n_gpu * w
+  logits_gpu.sync_from_device!("lm_head") if logits_gpu.device_dirty?
+  top = (0...logits_gpu.cols).max_by { |j| v = logits_gpu.raw_data[j]; v.nan? ? -1e30_f32 : v }
+  xn = SHAInet::SimpleMatrix.new(1, d)
+  d.times { |j| xn[0, j] = emb.embeddings[top, j] }
+  net.transformer_layers.each { |l| xn = l.as(SHAInet::LlamaBlock).forward_cached(xn) }
+  x = xn
+end
+elapsed = (Time.instant - t).total_seconds
+puts "#{n} tokens: #{elapsed.round(2)}s -> #{(elapsed / n).round(3)}s/token"

--- a/src/shainet/cuda.cr
+++ b/src/shainet/cuda.cr
@@ -15,6 +15,7 @@ module SHAInet
       fun cudaMallocHost(ptr : Pointer(Pointer(Void)), size : LibC::SizeT) : Int32
       fun cudaFreeHost(ptr : Pointer(Void)) : Int32
       fun cudaMemGetInfo(free : Pointer(LibC::SizeT), total : Pointer(LibC::SizeT)) : Int32
+      fun cudaDeviceSynchronize : Int32
     end
 
     @[Link("cublas")]
@@ -23,6 +24,7 @@ module SHAInet
 
       fun cublasCreate_v2(handle : Pointer(Handle)) : Int32
       fun cublasDestroy_v2(handle : Handle) : Int32
+      fun cublasSetMathMode(handle : Handle, mode : Int32) : Int32
       fun cublasSgemm_v2(handle : Handle, transa : Int32, transb : Int32,
                          m : Int32, n : Int32, k : Int32,
                          alpha : Pointer(Float32), a : Pointer(Float32), lda : Int32,
@@ -151,6 +153,10 @@ module SHAInet
       LibCUDARuntime.cudaMemcpy(dst, src, bytes, kind.value)
     end
 
+    def device_synchronize
+      LibCUDARuntime.cudaDeviceSynchronize
+    end
+
     def copy_device_to_device(dst : Pointer(Float32), src : Pointer(Float32), bytes : LibC::SizeT)
       memcpy(dst.as(Pointer(Void)), src.as(Pointer(Void)), bytes, MemcpyKind::DeviceToDevice)
     end
@@ -208,6 +214,9 @@ module SHAInet
 
       handle = Pointer(LibCUBLAS::Handle).malloc(1)
       raise "cublasCreate failed" unless LibCUBLAS.cublasCreate_v2(handle) == 0
+      # CUBLAS_MATH_DISALLOW_REDUCED_PRECISION_REDUCTION (16): prevent
+      # non-deterministic reduced-precision accumulation in SGEMM on Ada/Ampere.
+      LibCUBLAS.cublasSetMathMode(handle.value, 16)
       handle.value
     end
 

--- a/src/shainet/cuda.cr
+++ b/src/shainet/cuda.cr
@@ -216,7 +216,8 @@ module SHAInet
       raise "cublasCreate failed" unless LibCUBLAS.cublasCreate_v2(handle) == 0
       # CUBLAS_MATH_DISALLOW_REDUCED_PRECISION_REDUCTION (16): prevent
       # non-deterministic reduced-precision accumulation in SGEMM on Ada/Ampere.
-      LibCUBLAS.cublasSetMathMode(handle.value, 16)
+      result = LibCUBLAS.cublasSetMathMode(handle.value, 16)
+      Log.warn { "cublasSetMathMode failed (code #{result})" } unless result == 0
       handle.value
     end
 

--- a/src/shainet/safetensors.cr
+++ b/src/shainet/safetensors.cr
@@ -24,7 +24,7 @@ module SHAInet
         when F16, BF16, I16, U16 then 2
         when F32, I32, U32       then 4
         when F64, I64, U64       then 8
-        when I8, U8, BOOL       then 1
+        when I8, U8, BOOL        then 1
         else                          raise "Unknown dtype byte size"
         end
       end

--- a/src/shainet/text/bpe_tokenizer.cr
+++ b/src/shainet/text/bpe_tokenizer.cr
@@ -16,10 +16,24 @@ module SHAInet
     # GPT-2 byte-to-unicode mapping (lazily built). Maps a printable Unicode
     # codepoint back to the original raw byte it represents in byte-level BPE.
     @@unicode_to_byte : Hash(Char, UInt8)?
+    @@byte_to_unicode : Hash(UInt8, Char)?
 
     def self.unicode_to_byte(ch : Char) : UInt8
       map = (@@unicode_to_byte ||= build_byte_map)
       map[ch]? || 0_u8
+    end
+
+    def self.byte_to_unicode(b : UInt8) : Char
+      map = (@@byte_to_unicode ||= build_byte_to_unicode_map)
+      map[b]
+    end
+
+    private def self.build_byte_to_unicode_map : Hash(UInt8, Char)
+      # Inverse of build_byte_map
+      byte_map = (@@unicode_to_byte ||= build_byte_map)
+      inv = Hash(UInt8, Char).new
+      byte_map.each { |ch, b| inv[b] = ch }
+      inv
     end
 
     private def self.build_byte_map : Hash(Char, UInt8)
@@ -186,19 +200,17 @@ module SHAInet
     # HF-style encode: split on spaces, prefix with Ġ, apply BPE merges
     private def encode_hf(text : String) : Array(Int32)
       ids = Array(Int32).new
-      # Split into words keeping space as Ġ prefix
-      words = text.split(/(?= )| /)
-      words.each_with_index do |word, idx|
-        next if word.empty?
-        # Add Ġ prefix for space-separated words (except first if no leading space)
-        w = if word == " "
-              next # skip standalone spaces, handled by Ġ prefix
-            elsif idx > 0 || text.starts_with?(" ")
-              "Ġ" + word.lstrip
-            else
-              word
-            end
-        tokens = encode_tokens_hf(w)
+      return ids if text.empty?
+      # Convert raw bytes to GPT-2 unicode representation
+      unicode_text = String.build do |s|
+        text.bytes.each { |b| s << BPETokenizer.byte_to_unicode(b) }
+      end
+      # Split on spaces: each space becomes Ġ prefix on the following word
+      # Use regex to split into chunks: spaces attach to the following word
+      parts = unicode_text.scan(/\S+|\s+/)
+      parts.each do |m|
+        word = m[0]
+        tokens = encode_tokens_hf(word)
         tokens.each do |t|
           if id = @vocab[t]?
             ids << id

--- a/src/shainet/text/bpe_tokenizer.cr
+++ b/src/shainet/text/bpe_tokenizer.cr
@@ -197,7 +197,7 @@ module SHAInet
       ids
     end
 
-    # HF-style encode: split on spaces, prefix with Ġ, apply BPE merges
+    # HF-style encode: byte-level BPE with GPT-2 unicode mapping
     private def encode_hf(text : String) : Array(Int32)
       ids = Array(Int32).new
       return ids if text.empty?
@@ -205,16 +205,10 @@ module SHAInet
       unicode_text = String.build do |s|
         text.bytes.each { |b| s << BPETokenizer.byte_to_unicode(b) }
       end
-      # Split on spaces: each space becomes Ġ prefix on the following word
-      # Use regex to split into chunks: spaces attach to the following word
-      parts = unicode_text.scan(/\S+|\s+/)
-      parts.each do |m|
-        word = m[0]
-        tokens = encode_tokens_hf(word)
-        tokens.each do |t|
-          if id = @vocab[t]?
-            ids << id
-          end
+      tokens = encode_tokens_hf(unicode_text)
+      tokens.each do |t|
+        if id = @vocab[t]?
+          ids << id
         end
       end
       ids


### PR DESCRIPTION
## Summary

- Fix byte-level BPE encoder to map raw bytes through GPT-2 unicode table (fixes missing `\n\n` in chat template causing instruct model to diverge)
- Disable cuBLAS reduced-precision reduction (mode 16) to prevent TF32 non-determinism on RTX 30/40 GPUs
- GPU lm_head projection in llama_chat (was 2s/token on CPU for 128K vocab)
- NaN-safe sort + early exit in sampling loop
- Profiling example, bump max_tokens to 256, fix deprecation warnings
- Document TF32 note in README

## Testing

- `crystal spec` — 145 examples, 0 failures
- LLaMA 3.2 1B-Instruct generates coherent multi-paragraph responses with `NVIDIA_TF32_OVERRIDE=0`
- Greedy decode deterministic across runs with TF32 disabled

## Notes

Replaces the stale `perf/gpu-resident-inference` branch (can be deleted after merge).