### PR TITLE
perf: ~13x faster LLM decode (fix per-token full embedding-table copy)

### DIFF
--- a/src/shainet/math/cuda_matrix.cr
+++ b/src/shainet/math/cuda_matrix.cr
@@ -37,6 +37,8 @@ module SHAInet
 
     # Track allocation sites (callers)
     @@allocation_sites = Hash(String, UInt64).new(0_u64)
+    # Opt-in: capturing `caller` per allocation is expensive; off by default.
+    @@track_allocation_sites = !ENV["SHAINET_TRACK_ALLOCS"]?.nil?
 
     # Detailed sync tracking by source
     @@sync_sources = Hash(String, UInt64).new(0_u64)
@@ -109,9 +111,13 @@ module SHAInet
       # Count matrix creation
       @@matrix_creation_count += 1
 
-      # Track allocation site (top non-cuda_matrix.cr frame)
-      if call = caller.find { |c| !c.includes?("cuda_matrix.cr") }
-        @@allocation_sites[call] += 1
+      # Track allocation site (top non-cuda_matrix.cr frame). `caller` captures
+      # and symbolicates the full stack, which is very expensive (~0.25ms) and
+      # runs on every allocation, so it is opt-in via SHAINET_TRACK_ALLOCS.
+      if @@track_allocation_sites
+        if call = caller.find { |c| !c.includes?("cuda_matrix.cr") }
+          @@allocation_sites[call] += 1
+        end
       end
 
       # CudaMatrix requires CUDA to be available

--- a/src/shainet/text/embedding_layer.cr
+++ b/src/shainet/text/embedding_layer.cr
@@ -123,16 +123,25 @@ module SHAInet
     def embed_cpu(ids : Array(Int32)) : SimpleMatrix
       result = SimpleMatrix.zeros(ids.size, @l_size)
 
-      # Use CPU embeddings if available, otherwise sync from GPU
-      embeddings = if @embeddings.is_a?(SimpleMatrix)
-                     @embeddings.as(SimpleMatrix)
-                   else
-                     @embeddings.as(CudaMatrix).to_simple
-                   end
-
-      ids.each_with_index do |id, row|
-        @l_size.times do |col|
-          result[row, col] = embeddings[id, col]
+      emb = @embeddings
+      if emb.is_a?(SimpleMatrix)
+        src = emb.data
+        ids.each_with_index do |id, row|
+          base = id * @l_size
+          dst = row * @l_size
+          @l_size.times { |col| result.data[dst + col] = src[base + col] }
+        end
+      else
+        # CudaMatrix: the embedding values live in the host backing array.
+        # Gather only the requested rows instead of converting the whole
+        # [vocab, l_size] table (which was an O(vocab*l_size) copy per call).
+        cuda = emb.as(CudaMatrix)
+        cuda.sync_from_device!("embed_cpu") if cuda.device_dirty?
+        src = cuda.raw_data
+        ids.each_with_index do |id, row|
+          base = id * @l_size
+          dst = row * @l_size
+          @l_size.times { |col| result.data[dst + col] = src[base + col] }
         end
       end
 


### PR DESCRIPTION
## Summary

Profiling the Q8 decode path showed the Q8 kernels were only ~4 ms of a ~430 ms
token — so I traced where the rest went. The culprit was **not** quantization,
attention, or the FFN. It was the embedding lookup.

### Root cause

`EmbeddingLayer#embed_cpu` converted the **entire** `[vocab, l_size]` embedding
table (128256×2048 for LLaMA 3.2 1B) from `CudaMatrix` to `SimpleMatrix` via
`to_simple` on **every token**, just to read a single row — a ~262M-element copy,
**~400 ms/token**. Measured per-token breakdown before the fix:

| stage | time |
|---|---|
| **embed** | **~400 ms** |
| attention (16 layers) | ~17 ms |
| FFN (16 layers) | ~13 ms |
| lm_head | ~3 ms |
| 8 Q8 GEMV kernels | ~4 ms |

### Fix

Gather only the requested rows directly from the host backing array
(`O(ids · l_size)` instead of `O(vocab · l_size)`), for both the `SimpleMatrix`
and `CudaMatrix` cases. Values are identical — there's just no full-table copy.

Also gate `CudaMatrix.new`'s per-allocation `caller` stack capture (~0.25 ms
each, on every matrix allocation) behind `SHAINET_TRACK_ALLOCS` (off by default).

## Result

LLaMA 3.2 1B, Q8, RTX 4090: **2.3 → ~29 tok/s**, output unchanged
("The largest dog breed is the Irish Wolfhound..."). Benefits the fp32 path too.
147 specs pass; builds clean with and without `-Denable_cuda`.

## Follow-up

With embed fixed, attention (~17 ms) and FFN (~13 ms) dominate, mostly CPU
orchestration (`SimpleMatrix`↔`CudaMatrix` round-trips, per-call `cudaMalloc`).
A full on-device decode (keep the token resident on GPU, reuse buffers, GPU
attention/softmax/RoPE) is the next step toward 100+ tok/s.