### PR TITLE
perf: ~3x faster decode (flat-cache attention, GEMV buffer reuse, better Q8 kernel)

### DIFF
--- a/src/shainet/basic/network_run.cr
+++ b/src/shainet/basic/network_run.cr
@@ -1488,11 +1488,13 @@ module SHAInet
                matrix
              end
 
-      x_gpu = CudaMatrix.new(last.rows, last.cols)
+      x_gpu = (@lm_head_x ||= CudaMatrix.new(last.rows, last.cols))
       x_gpu.raw_data.to_unsafe.copy_from(last.data.to_unsafe, last.rows * last.cols)
+      x_gpu.mark_host_modified!
       x_gpu.sync_to_device!("lm_head_q_in")
 
-      r_gpu = weights.gemv(x_gpu)
+      r_gpu = (@lm_head_r ||= CudaMatrix.new(last.rows, weights.cols))
+      weights.gemv_into(x_gpu, r_gpu)
       r_gpu.sync_from_device!("lm_head_q_out") if r_gpu.device_dirty?
 
       result = SimpleMatrix.new(r_gpu.rows, r_gpu.cols)

--- a/src/shainet/basic/network_setup.cr
+++ b/src/shainet/basic/network_setup.cr
@@ -39,6 +39,9 @@ module SHAInet
 
     # Quantized lm_head weight (populated by quantize! when CUDA is available).
     @lm_head_q : QuantizedCudaMatrix? = nil
+    # Persistent decode buffers for the quantized lm_head GEMV (reused per token).
+    @lm_head_x : CudaMatrix? = nil
+    @lm_head_r : CudaMatrix? = nil
 
     # Parameters for Rprop
     property etah_plus : Float64, etah_minus : Float64, delta_max : Float64, delta_min : Float64

--- a/src/shainet/math/cuda_matrix.cr
+++ b/src/shainet/math/cuda_matrix.cr
@@ -704,6 +704,14 @@ module SHAInet
       @device_dirty = false
     end
 
+    # Mark host data as modified since the last device sync. Needed when callers
+    # mutate the backing array via raw_data/unsafe_set and then expect
+    # sync_to_device! to re-upload (otherwise the @host_modified skip from #113
+    # would treat the buffer as already in sync).
+    def mark_host_modified!
+      @host_modified = true
+    end
+
     def to_a
       # Ensure CPU data is up to date (single sync instead of per-element)
       sync_from_device!("bulk_to_a") if device_dirty?

--- a/src/shainet/math/quantized_cuda_matrix.cr
+++ b/src/shainet/math/quantized_cuda_matrix.cr
@@ -123,5 +123,19 @@ module SHAInet
       result.mark_device_dirty!
       result
     end
+
+    # Same as gemv but writes into a caller-provided result buffer, avoiding a
+    # per-call device allocation. result must be [x.rows, cols].
+    def gemv_into(x : CudaMatrix, result : CudaMatrix) : CudaMatrix
+      raise ArgumentError.new("dimension mismatch: x.cols=#{x.cols} vs K=#{@rows}") unless x.cols == @rows
+      raise ArgumentError.new("result shape mismatch") unless result.rows == x.rows && result.cols == @cols
+      raise RuntimeError.new("Q8 gemv requires valid device pointers") if @q_ptr.null? || @scale_ptr.null?
+
+      x.sync_to_device!("q8_gemv_in") unless x.device_dirty?
+      CUDA.gemm_q8_f32(x.device_ptr.not_nil!, @q_ptr, @scale_ptr,
+        result.device_ptr.not_nil!, x.rows, @cols, @rows)
+      result.mark_device_dirty!
+      result
+    end
   end
 end

--- a/src/shainet/native/cuda_kernels.cu
+++ b/src/shainet/native/cuda_kernels.cu
@@ -594,18 +594,13 @@ __global__ void gemm_q8_f32_kernel(const float* __restrict__ x,
 
     int tid = threadIdx.x;
     int nthreads = blockDim.x;
-    float partial = 0.0f;
 
-    for (int b = tid; b < nblocks; b += nthreads) {
-        float s = srow[b];
-        int base = b * Q8_BLK;
-        int lim = base + Q8_BLK;
-        if (lim > K) lim = K;
-        float acc = 0.0f;
-        for (int k = base; k < lim; ++k) {
-            acc += (float)qrow[k] * xrow[k];
-        }
-        partial += acc * s;
+    // Each thread strides over the full K dimension so all threads do work
+    // (the previous one-thread-per-32-block scheme left most threads idle for
+    // small K). Scale is per-32-element block; srow is tiny and L1/L2 cached.
+    float partial = 0.0f;
+    for (int k = tid; k < K; k += nthreads) {
+        partial += (float)qrow[k] * xrow[k] * srow[k >> 5];
     }
 
     extern __shared__ float sdata[];

--- a/src/shainet/transformer/llama_block.cr
+++ b/src/shainet/transformer/llama_block.cr
@@ -46,6 +46,12 @@ module SHAInet
       @v_cache = Array.new(@num_kv_heads) { Array(Float32).new }
     end
 
+    # Persistent single-row GEMV workspaces for decode (M=1), keyed by width.
+    # Reused across tokens to avoid per-call cudaMalloc/cudaFree churn. Never
+    # freed during inference, so they cannot be GC-collected mid-GEMM.
+    @q8_in_bufs = Hash(Int32, CudaMatrix).new
+    @q8_out_bufs = Hash(Int32, CudaMatrix).new
+
     def clear_cache!
       @k_cache.each(&.clear)
       @v_cache.each(&.clear)
@@ -193,40 +199,92 @@ module SHAInet
       output = SimpleMatrix.new(new_tokens, @d_model)
       heads_per_kv = @num_heads // @num_kv_heads
 
+      half = head_dim // 2
+      dm = @d_model
+      qdata = q_full.data
+      odata = output.data
+      # Reusable scratch buffers (avoid per-head/per-token allocations).
+      q_rot = Array(Float32).new(head_dim, 0.0_f32)
+      scores = Array(Float32).new(total_len, 0.0_f32)
+      out = Array(Float32).new(head_dim, 0.0_f32)
+
       @num_heads.times do |h|
         q_col = h * head_dim
         kv_h = h // heads_per_kv
+        kcache = @k_cache[kv_h]
+        vcache = @v_cache[kv_h]
 
-        # Q for new tokens only
-        q_h = extract_head(q_full, new_tokens, q_col, head_dim)
-        apply_rope!(q_h, start_pos)
-
-        # K/V from cache (K already has RoPE applied at insert time)
-        k_h = cache_to_matrix(@k_cache[kv_h], total_len, head_dim)
-        v_h = cache_to_matrix(@v_cache[kv_h], total_len, head_dim)
-
-        # Attention: new Q [new_tokens, hd] @ cached K^T [hd, total_len]
-        k_t = k_h.transpose
-        scores = q_h * k_t # [new_tokens, total_len]
-
-        # Causal softmax (each new token can see all cached + itself)
-        attn_weights = SimpleMatrix.new(new_tokens, total_len)
         new_tokens.times do |i|
-          visible = start_pos + i + 1 # this token can see positions 0..start_pos+i
-          max_val = -Float32::INFINITY
-          visible.times { |j| sv = scores[i, j].to_f32 * scale; max_val = sv if sv > max_val }
-          exp_sum = 0.0_f32
-          visible.times do |j|
-            e = Math.exp((scores[i, j].to_f32 * scale - max_val).to_f64).to_f32
-            attn_weights[i, j] = e
-            exp_sum += e
-          end
-          visible.times { |j| attn_weights[i, j] = attn_weights[i, j].to_f32 / exp_sum }
-        end
+          pos = start_pos + i
+          qrow = i * dm + q_col
 
-        attn_out = attn_weights * v_h # [new_tokens, head_dim]
-        new_tokens.times do |s|
-          head_dim.times { |d| output[s, q_col + d] = attn_out[s, d] }
+          # RoPE-rotate this token's Q head directly into q_rot (HF half-split).
+          idx = 0
+          while idx < half
+            freq = inv_freq(idx)
+            angle = (pos * freq).to_f32
+            c = Math.cos(angle).to_f32
+            s = Math.sin(angle).to_f32
+            x0 = qdata[qrow + idx]
+            x1 = qdata[qrow + idx + half]
+            q_rot[idx] = x0 * c - x1 * s
+            q_rot[idx + half] = x1 * c + x0 * s
+            idx += 1
+          end
+
+          # scores[j] = scale * (q_rot · K_cache[j]); track max for stable softmax.
+          visible = start_pos + i + 1
+          max_val = -Float32::INFINITY
+          j = 0
+          while j < visible
+            kbase = j * head_dim
+            dot = 0.0_f32
+            d = 0
+            while d < head_dim
+              dot += q_rot[d] * kcache[kbase + d]
+              d += 1
+            end
+            sv = dot * scale
+            scores[j] = sv
+            max_val = sv if sv > max_val
+            j += 1
+          end
+
+          # softmax over visible positions
+          exp_sum = 0.0_f32
+          j = 0
+          while j < visible
+            e = Math.exp((scores[j] - max_val).to_f64).to_f32
+            scores[j] = e
+            exp_sum += e
+            j += 1
+          end
+          inv_sum = 1.0_f32 / exp_sum
+
+          # out = sum_j (softmax_j) * V_cache[j]
+          d = 0
+          while d < head_dim
+            out[d] = 0.0_f32
+            d += 1
+          end
+          j = 0
+          while j < visible
+            w = scores[j] * inv_sum
+            vbase = j * head_dim
+            d = 0
+            while d < head_dim
+              out[d] += w * vcache[vbase + d]
+              d += 1
+            end
+            j += 1
+          end
+
+          orow = i * dm + q_col
+          d = 0
+          while d < head_dim
+            odata[orow + d] = out[d]
+            d += 1
+          end
         end
       end
 
@@ -347,15 +405,29 @@ module SHAInet
     # --- Helper: matmul using GPU SGEMM if weights are CudaMatrix ---
     private def gpu_matmul(x : SimpleMatrix, w : SimpleMatrix | CudaMatrix | QuantizedCudaMatrix) : SimpleMatrix
       if w.is_a?(QuantizedCudaMatrix)
-        # Quantized GPU GEMV: bulk upload activations, dequant-in-kernel matmul, bulk download
-        x_gpu = CudaMatrix.new(x.rows, x.cols)
-        x_gpu.raw_data.to_unsafe.copy_from(x.data.to_unsafe, x.rows * x.cols)
-        x_gpu.sync_to_device!("q8_gemm_in")
-        result_gpu = w.gemv(x_gpu)
-        result_gpu.sync_from_device!("q8_gemm_out") if result_gpu.device_dirty?
-        result = SimpleMatrix.new(result_gpu.rows, result_gpu.cols)
-        result.data.to_unsafe.copy_from(result_gpu.raw_data.to_unsafe, result_gpu.rows * result_gpu.cols)
-        result
+        if x.rows == 1
+          # Decode (M=1): reuse persistent device buffers, no per-call alloc/free.
+          xb = (@q8_in_bufs[x.cols] ||= CudaMatrix.new(1, x.cols))
+          xb.raw_data.to_unsafe.copy_from(x.data.to_unsafe, x.cols)
+          xb.mark_host_modified!
+          xb.sync_to_device!("q8_gemm_in")
+          ob = (@q8_out_bufs[w.cols] ||= CudaMatrix.new(1, w.cols))
+          w.gemv_into(xb, ob)
+          ob.sync_from_device!("q8_gemm_out") if ob.device_dirty?
+          result = SimpleMatrix.new(1, w.cols)
+          result.data.to_unsafe.copy_from(ob.raw_data.to_unsafe, w.cols)
+          result
+        else
+          # Prefill / batch (M>1): one-off allocation.
+          x_gpu = CudaMatrix.new(x.rows, x.cols)
+          x_gpu.raw_data.to_unsafe.copy_from(x.data.to_unsafe, x.rows * x.cols)
+          x_gpu.sync_to_device!("q8_gemm_in")
+          result_gpu = w.gemv(x_gpu)
+          result_gpu.sync_from_device!("q8_gemm_out") if result_gpu.device_dirty?
+          result = SimpleMatrix.new(result_gpu.rows, result_gpu.cols)
+          result.data.to_unsafe.copy_from(result_gpu.raw_data.to_unsafe, result_gpu.rows * result_gpu.cols)
+          result
+        end
       elsif w.is_a?(CudaMatrix)
         # Convert input to GPU, GEMM, bring back
         x_gpu = CudaMatrix.new(x.rows, x.cols)

--- a/src/shainet/transformer/swiglu_ff.cr
+++ b/src/shainet/transformer/swiglu_ff.cr
@@ -12,6 +12,10 @@ module SHAInet
       @down_proj = SimpleMatrix.new(ff_hidden, d_model)
     end
 
+    # Persistent single-row GEMV workspaces for decode (M=1), keyed by width.
+    @q8_in_bufs = Hash(Int32, CudaMatrix).new
+    @q8_out_bufs = Hash(Int32, CudaMatrix).new
+
     def to_gpu!(quantize : Bool = false)
       return unless CUDA.fully_available?
       if quantize
@@ -76,14 +80,27 @@ module SHAInet
 
     private def matmul(x : SimpleMatrix, w : SimpleMatrix | CudaMatrix | QuantizedCudaMatrix) : SimpleMatrix
       if w.is_a?(QuantizedCudaMatrix)
-        x_gpu = CudaMatrix.new(x.rows, x.cols)
-        x_gpu.raw_data.to_unsafe.copy_from(x.data.to_unsafe, x.rows * x.cols)
-        x_gpu.sync_to_device!("q8_ffn_in")
-        result_gpu = w.gemv(x_gpu)
-        result_gpu.sync_from_device!("q8_ffn_out") if result_gpu.device_dirty?
-        result = SimpleMatrix.new(result_gpu.rows, result_gpu.cols)
-        result.data.to_unsafe.copy_from(result_gpu.raw_data.to_unsafe, result_gpu.rows * result_gpu.cols)
-        result
+        if x.rows == 1
+          xb = (@q8_in_bufs[x.cols] ||= CudaMatrix.new(1, x.cols))
+          xb.raw_data.to_unsafe.copy_from(x.data.to_unsafe, x.cols)
+          xb.mark_host_modified!
+          xb.sync_to_device!("q8_ffn_in")
+          ob = (@q8_out_bufs[w.cols] ||= CudaMatrix.new(1, w.cols))
+          w.gemv_into(xb, ob)
+          ob.sync_from_device!("q8_ffn_out") if ob.device_dirty?
+          result = SimpleMatrix.new(1, w.cols)
+          result.data.to_unsafe.copy_from(ob.raw_data.to_unsafe, w.cols)
+          result
+        else
+          x_gpu = CudaMatrix.new(x.rows, x.cols)
+          x_gpu.raw_data.to_unsafe.copy_from(x.data.to_unsafe, x.rows * x.cols)
+          x_gpu.sync_to_device!("q8_ffn_in")
+          result_gpu = w.gemv(x_gpu)
+          result_gpu.sync_from_device!("q8_ffn_out") if result_gpu.device_dirty?
+          result = SimpleMatrix.new(result_gpu.rows, result_gpu.cols)
+          result.data.to_unsafe.copy_from(result_gpu.raw_data.to_unsafe, result_gpu.rows * result_gpu.cols)
+          result
+        end
       elsif w.is_a?(CudaMatrix)
         x_gpu = CudaMatrix.new(x.rows, x.cols)
         x.rows.times { |r| x.cols.times { |c| x_gpu[r, c] = x[r, c] } }


### PR DESCRIPTION
## Summary

Builds on #116. Profiling the ~25 tok/s decode showed three hotspots — none of
them the quant math itself. Fixed all three; LLaMA 3.2 1B (Q8, RTX 4090) goes
**~25 → ~75 tok/s**. Output unchanged, numerics cosine ≈ 1 vs fp32.

### Profiled hotspots (64-token decode, before → after)

| stage | before | after |
|---|---|---|
| attention head loop | ~1100 ms | ~220 ms |
| FFN gate/up GEMM | ~430 ms | ~200 ms |
| qkv GEMM | ~377 ms | ~95 ms |
| FFN down GEMM | ~200 ms | ~98 ms |

### 1. Flat-cache attention (biggest win)

The CPU attention rebuilt a `[total_len, head_dim]` `SimpleMatrix` for **K and
V, per head, per token** (`cache_to_matrix`) and ran generic `SimpleMatrix`
matmuls + transpose — cost grew with context. Rewrote the head loop to compute
scores / softmax / attention·V **directly on the flat KV-cache arrays** with
reused scratch buffers: no per-head allocation, no transpose, no generic matmul.

### 2. Persistent GEMV buffers (no per-token cudaMalloc)

Every projection/FFN GEMV allocated + freed a `CudaMatrix` (~0.28 ms each,
~14/token) plus GC churn. Added persistent per-block decode buffers (M=1) reused
across tokens via `QuantizedCudaMatrix#gemv_into`, plus reused lm_head buffers.
They're never freed during inference, so they also **can't be GC-collected
mid-GEMM** (the failure mode from the original stability saga). Added
`CudaMatrix#mark_host_modified!` so `raw_data` writes re-sync correctly (the
latent flag flaw flagged back in #113).

### 3. Better Q8 GEMV kernel occupancy

The kernel used one thread per 32-element block, leaving most of a 256-thread
block idle for small K. Reworked so **every thread strides the full K
dimension**; the per-block scale is applied per element from the (cached) scale
array. FFN/attention GEMMs roughly halved.

## Verification

- Output unchanged ("The largest dog breed is the Irish Wolfhound...").
- Numerics: `QuantizedCudaMatrix` spec cosine ≈ 1 vs fp32 still passes.
- 147 CPU specs + 9 CUDA-path specs (quant, cuda_matrix, llama_loader,
  embedding) pass. Builds clean with and without `-Denable_cuda`.
- Prefill (M>1) keeps the existing allocating path; only decode (M=1) uses the
  reuse buffers.

## Cumulative

Original Q8 decode was ~2.3 tok/s. With #116 (embedding fix) and this PR: ~75
tok/s — a ~32x improvement, all from fixing orchestration/CPU hotspots, not the
quant kernels.

## Build

Kernel change requires rebuilding the `.so`:
\`\`\`
nvcc -shared --compiler-options=-fPIC -O3 -arch=sm_89 \
  -I/opt/cuda/include -L/opt/cuda/lib64 -lcurand \
  src/shainet/native/cuda_kernels.cu -o libshainet_cuda_kernels.so
\`\`\`

## Possible follow-ups

attn.heads (CPU) and the GEMV kernels are now balanced. Further gains would need
GPU-side attention or vectorized int8 loads (char4) — diminishing returns with
rising complexity.