### PR TITLE
feat: Qwen2 support via Network#run (Q/K/V biases) + build-script arch autodetect

### DIFF
--- a/build_cuda_kernels.sh
+++ b/build_cuda_kernels.sh
@@ -17,13 +17,37 @@ if ! command -v nvcc &> /dev/null; then
     exit 0  # Exit successfully to not break shards install
 fi
 
-# Set CUDA paths (adjust if needed)
-CUDA_PATH=${CUDA_PATH:-/usr/local/cuda}
+# Locate the CUDA toolkit: prefer nvcc's own install prefix, then common paths.
+# Override by exporting CUDA_PATH.
+if [ -z "${CUDA_PATH}" ]; then
+    NVCC_BIN="$(command -v nvcc)"
+    if [ -n "${NVCC_BIN}" ]; then
+        CUDA_PATH="$(dirname "$(dirname "${NVCC_BIN}")")"
+    elif [ -d /opt/cuda ]; then
+        CUDA_PATH=/opt/cuda
+    else
+        CUDA_PATH=/usr/local/cuda
+    fi
+fi
 SRC_DIR="src/shainet/native"
 OUTPUT_LIB="libshainet_cuda_kernels.so"
 
+# Detect the GPU's compute capability and target it (e.g. 8.9 -> sm_89).
+# Override by exporting CUDA_ARCH (e.g. CUDA_ARCH=sm_89).
+if [ -z "${CUDA_ARCH}" ]; then
+    CAP="$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null | head -1 | tr -d '. ')"
+    if [ -n "${CAP}" ]; then
+        CUDA_ARCH="sm_${CAP}"
+    else
+        CUDA_ARCH="sm_75"  # oldest arch supported by recent CUDA toolkits
+        echo "Note: could not detect GPU; defaulting to ${CUDA_ARCH}. Override with CUDA_ARCH=sm_XX."
+    fi
+fi
+
+echo "Using CUDA toolkit at ${CUDA_PATH}, target architecture ${CUDA_ARCH}"
+
 # Compilation flags
-NVCC_FLAGS="-shared --compiler-options=-fPIC -O3 -arch=sm_60"
+NVCC_FLAGS="-shared --compiler-options=-fPIC -O3 -arch=${CUDA_ARCH}"
 INCLUDE_FLAGS="-I${CUDA_PATH}/include"
 LIBRARY_FLAGS="-L${CUDA_PATH}/lib64 -lcurand"
 

--- a/examples/llama_chat.cr
+++ b/examples/llama_chat.cr
@@ -126,10 +126,10 @@ loop do
   print "LLaMA: "
 
   # Stop on whichever end-of-turn / end-of-text tokens this model defines.
-  stop_ids = Set(Int32).new
+  stop_ids = [] of Int32
   ["<|eot_id|>", "<|end_of_text|>", "<|im_end|>", "<|endoftext|>"].each do |name|
     if id = tokenizer.vocab[name]?
-      stop_ids << id
+      stop_ids << id unless stop_ids.includes?(id)
     end
   end
   generated_ids = Array(Int32).new

--- a/examples/llama_chat.cr
+++ b/examples/llama_chat.cr
@@ -43,7 +43,7 @@ model_dir =
 # --- Load model ---
 STDERR.puts "Loading model from #{model_dir}..."
 t = Time.instant
-net = SHAInet::HFLoader.load_llama(model_dir)
+net = SHAInet::HFLoader.load(model_dir)
 STDERR.puts "Model loaded in #{(Time.instant - t).total_seconds.round(1)}s"
 STDERR.puts "  Layers: #{net.transformer_layers.size}, d_model: #{net.transformer_layers.first.as(SHAInet::LlamaBlock).d_model}"
 
@@ -76,15 +76,30 @@ loop do
 
   net.clear_cache!
 
-  # Build prompt with LLaMA 3 chat template
+  # Build prompt using whichever chat template the tokenizer supports.
   sp = ->(name : String) { tokenizer.vocab[name]? }
   bos = sp.call("<|begin_of_text|>")
   start_hdr = sp.call("<|start_header_id|>")
   end_hdr = sp.call("<|end_header_id|>")
   eot = sp.call("<|eot_id|>")
+  im_start = sp.call("<|im_start|>")
+  im_end = sp.call("<|im_end|>")
 
   prompt_ids = [] of Int32
-  if bos && start_hdr && end_hdr && eot
+  if im_start && im_end
+    # Qwen / ChatML: <|im_start|>user\n{msg}<|im_end|>\n<|im_start|>assistant\n
+    nl = tokenizer.encode("\n")
+    prompt_ids << im_start
+    prompt_ids.concat(tokenizer.encode("user"))
+    prompt_ids.concat(nl)
+    prompt_ids.concat(tokenizer.encode(user_input.strip))
+    prompt_ids << im_end
+    prompt_ids.concat(nl)
+    prompt_ids << im_start
+    prompt_ids.concat(tokenizer.encode("assistant"))
+    prompt_ids.concat(nl)
+  elsif bos && start_hdr && end_hdr && eot
+    # LLaMA 3 chat template
     nl = tokenizer.encode("\n\n")
     prompt_ids << bos << start_hdr
     prompt_ids.concat(tokenizer.encode("user"))
@@ -110,8 +125,13 @@ loop do
   STDERR.print "\r" + " " * 40 + "\r"
   print "LLaMA: "
 
-  eot_id = tokenizer.vocab["<|eot_id|>"]? || -1
-  eos_id = tokenizer.vocab["<|end_of_text|>"]? || -1
+  # Stop on whichever end-of-turn / end-of-text tokens this model defines.
+  stop_ids = Set(Int32).new
+  ["<|eot_id|>", "<|end_of_text|>", "<|im_end|>", "<|endoftext|>"].each do |name|
+    if id = tokenizer.vocab[name]?
+      stop_ids << id
+    end
+  end
   generated_ids = Array(Int32).new
   sampler = SHAInet::Sampler.new(temperature: 0.6, top_k: 40, repetition_penalty: 1.2)
   gen_start = Time.instant
@@ -123,7 +143,7 @@ loop do
     sampler.apply_repetition_penalty!(logits, generated_ids, window: 20, row: last_row)
     best_id = sampler.sample(logits, last_row)
 
-    break if best_id == eot_id || best_id == eos_id || best_id < 0
+    break if best_id < 0 || stop_ids.includes?(best_id)
     break unless logits[last_row, best_id].finite?
     generated_ids << best_id
     print tokenizer.decode([best_id])

--- a/spec/llama_qkv_bias_spec.cr
+++ b/spec/llama_qkv_bias_spec.cr
@@ -1,0 +1,73 @@
+require "./spec_helper"
+
+# Verifies Qwen2-style Q/K/V projection biases flow through the cached
+# (Network#run) attention path on CPU, and that the LLaMA default (no bias)
+# is unaffected. Forces the CPU attention path so the test is deterministic
+# and independent of CUDA/VRAM.
+describe SHAInet::LlamaBlock do
+  it "treats nil bias and zero bias identically (LLaMA path unchanged)" do
+    d_model = 8
+    block_a = SHAInet::LlamaBlock.new(d_model, num_heads: 2, ff_hidden: 16, num_kv_heads: 2)
+    block_b = SHAInet::LlamaBlock.new(d_model, num_heads: 2, ff_hidden: 16, num_kv_heads: 2)
+    block_a.force_cpu_attention = true
+    block_b.force_cpu_attention = true
+
+    # Identical random-ish weights for both blocks.
+    seed = SHAInet::SimpleMatrix.new(d_model, d_model)
+    d_model.times { |i| d_model.times { |j| seed[i, j] = ((i * 7 + j * 3) % 5 - 2) * 0.1 } }
+    [block_a, block_b].each do |bl|
+      bl.w_q = seed.clone
+      bl.w_k = seed.clone
+      bl.w_v = seed.clone
+      bl.w_o = seed.clone
+      d_model.times { |j| bl.norm1.gamma.not_nil![0, j] = 1.0; bl.norm2.gamma.not_nil![0, j] = 1.0 }
+    end
+
+    # b only differs by being nil vs all-zeros — must produce identical output.
+    block_b.b_q = Array(Float32).new(d_model, 0.0_f32)
+    block_b.b_k = Array(Float32).new(d_model, 0.0_f32)
+    block_b.b_v = Array(Float32).new(d_model, 0.0_f32)
+
+    x = SHAInet::SimpleMatrix.new(1, d_model)
+    d_model.times { |j| x[0, j] = (j - 4) * 0.05 }
+
+    out_a = block_a.forward_cached(x.clone)
+    out_b = block_b.forward_cached(x.clone)
+
+    d_model.times do |j|
+      out_b[0, j].should be_close(out_a[0, j], 1e-6)
+    end
+  end
+
+  it "shifts the output when a non-zero QKV bias is set" do
+    d_model = 8
+    base = SHAInet::LlamaBlock.new(d_model, num_heads: 2, ff_hidden: 16, num_kv_heads: 2)
+    biased = SHAInet::LlamaBlock.new(d_model, num_heads: 2, ff_hidden: 16, num_kv_heads: 2)
+    base.force_cpu_attention = true
+    biased.force_cpu_attention = true
+
+    seed = SHAInet::SimpleMatrix.new(d_model, d_model)
+    d_model.times { |i| d_model.times { |j| seed[i, j] = ((i + j) % 3 - 1) * 0.1 } }
+    [base, biased].each do |bl|
+      bl.w_q = seed.clone
+      bl.w_k = seed.clone
+      bl.w_v = seed.clone
+      bl.w_o = seed.clone
+      d_model.times { |j| bl.norm1.gamma.not_nil![0, j] = 1.0; bl.norm2.gamma.not_nil![0, j] = 1.0 }
+    end
+
+    biased.b_q = Array(Float32).new(d_model) { |i| (i + 1) * 0.3_f32 }
+    biased.b_k = Array(Float32).new(d_model) { |i| (i + 1) * 0.2_f32 }
+    biased.b_v = Array(Float32).new(d_model) { |i| (i + 1) * 0.5_f32 }
+
+    x = SHAInet::SimpleMatrix.new(1, d_model)
+    d_model.times { |j| x[0, j] = (j - 4) * 0.05 }
+
+    out_base = base.forward_cached(x.clone)
+    out_biased = biased.forward_cached(x.clone)
+
+    # The V bias in particular must move the attention output, hence the block output.
+    diff = (0...d_model).sum { |j| (out_biased[0, j] - out_base[0, j]).abs }
+    diff.should be > 0.01
+  end
+end

--- a/src/shainet/hf_loader.cr
+++ b/src/shainet/hf_loader.cr
@@ -295,11 +295,15 @@ module SHAInet
           block.norm2.gamma = sf.read_matrix("#{prefix}.post_attention_layernorm.weight")
 
           # Optional Q/K/V projection biases — present in Qwen2-style models,
-          # absent in LLaMA/Mistral. Loaded as host-side fp32 vectors.
-          if sf.has_tensor?("#{prefix}.self_attn.q_proj.bias")
-            block.b_q = sf.read_f64("#{prefix}.self_attn.q_proj.bias").map(&.to_f32)
-            block.b_k = sf.read_f64("#{prefix}.self_attn.k_proj.bias").map(&.to_f32)
-            block.b_v = sf.read_f64("#{prefix}.self_attn.v_proj.bias").map(&.to_f32)
+          # absent in LLaMA/Mistral. They always appear as a complete set.
+          has_q = sf.has_tensor?("#{prefix}.self_attn.q_proj.bias")
+          has_k = sf.has_tensor?("#{prefix}.self_attn.k_proj.bias")
+          has_v = sf.has_tensor?("#{prefix}.self_attn.v_proj.bias")
+          if has_q || has_k || has_v
+            raise "Incomplete Q/K/V projection biases for #{prefix} (q=#{has_q} k=#{has_k} v=#{has_v})" unless has_q && has_k && has_v
+            block.b_q = sf.read_f32("#{prefix}.self_attn.q_proj.bias")
+            block.b_k = sf.read_f32("#{prefix}.self_attn.k_proj.bias")
+            block.b_v = sf.read_f32("#{prefix}.self_attn.v_proj.bias")
           end
         end
 

--- a/src/shainet/hf_loader.cr
+++ b/src/shainet/hf_loader.cr
@@ -5,7 +5,7 @@ module SHAInet
   # Load a GPT-2 model directly from a HuggingFace SafeTensors file.
   # No Python, no PyTorch — pure Crystal.
   module HFLoader
-    SUPPORTED_MODELS = ["gpt2", "llama", "mistral"]
+    SUPPORTED_MODELS = ["gpt2", "llama", "mistral", "qwen2"]
 
     # Generic entry point — reads config.json and dispatches to the right loader.
     def self.load(model_dir : String) : Network
@@ -18,7 +18,7 @@ module SHAInet
       case model_type
       when "gpt2"
         load_gpt2(model_dir)
-      when "llama", "mistral"
+      when "llama", "mistral", "qwen2"
         load_llama(model_dir)
       else
         raise "Unsupported model_type: '#{model_type}'. Supported: #{SUPPORTED_MODELS.join(", ")}"
@@ -293,6 +293,14 @@ module SHAInet
           # RMSNorm
           block.norm1.gamma = sf.read_matrix("#{prefix}.input_layernorm.weight")
           block.norm2.gamma = sf.read_matrix("#{prefix}.post_attention_layernorm.weight")
+
+          # Optional Q/K/V projection biases — present in Qwen2-style models,
+          # absent in LLaMA/Mistral. Loaded as host-side fp32 vectors.
+          if sf.has_tensor?("#{prefix}.self_attn.q_proj.bias")
+            block.b_q = sf.read_f64("#{prefix}.self_attn.q_proj.bias").map(&.to_f32)
+            block.b_k = sf.read_f64("#{prefix}.self_attn.k_proj.bias").map(&.to_f32)
+            block.b_v = sf.read_f64("#{prefix}.self_attn.v_proj.bias").map(&.to_f32)
+          end
         end
 
         # Output head

--- a/src/shainet/transformer/llama_block.cr
+++ b/src/shainet/transformer/llama_block.cr
@@ -536,6 +536,7 @@ module SHAInet
     # --- Helper: add a per-column bias vector to every row, in-place (host) ---
     private def add_bias!(m : SimpleMatrix, b : Array(Float32)?)
       return unless b
+      raise ArgumentError.new("bias size #{b.size} does not match matrix cols #{m.cols}") unless b.size == m.cols
       bp = b.to_unsafe
       data = m.data.to_unsafe
       cols = m.cols
@@ -555,6 +556,7 @@ module SHAInet
     # projection result has been synced back to host for per-head processing.
     private def add_bias!(m : CudaMatrix, b : Array(Float32)?)
       return unless b
+      raise ArgumentError.new("bias size #{b.size} does not match matrix cols #{m.cols}") unless b.size == m.cols
       m.rows.times { |r| m.cols.times { |c| m[r, c] = (m[r, c].to_f32 + b[c]) } }
     end
 

--- a/src/shainet/transformer/llama_block.cr
+++ b/src/shainet/transformer/llama_block.cr
@@ -22,6 +22,16 @@ module SHAInet
     property w_v : SimpleMatrix | CudaMatrix | QuantizedCudaMatrix
     property w_o : SimpleMatrix | CudaMatrix | QuantizedCudaMatrix
 
+    # Optional Q/K/V projection biases. Qwen2-style architectures add a bias to
+    # the query/key/value projections; LLaMA/Mistral do not. Kept as host-side
+    # fp32 vectors and added to the projection output before RoPE, so they work
+    # identically on the fp32, CUDA, and Q8 weight paths. nil means "no bias"
+    # (the LLaMA default — zero overhead, behaviour unchanged). Sizes: b_q is
+    # d_model; b_k/b_v are num_kv_heads * head_dim. o_proj has no bias in Qwen2.
+    property b_q : Array(Float32)? = nil
+    property b_k : Array(Float32)? = nil
+    property b_v : Array(Float32)? = nil
+
     # KV cache: stored per kv_head as [seq_len, head_dim] growing matrices
     @k_cache : Array(Array(Float32)) # [num_kv_heads][seq_len * head_dim]
     @v_cache : Array(Array(Float32))
@@ -165,6 +175,9 @@ module SHAInet
       q_full = gpu_matmul(x, @w_q) # [seq, d_model]
       k_full = gpu_matmul(x, @w_k) # [seq, kv_dim]
       v_full = gpu_matmul(x, @w_v) # [seq, kv_dim]
+      add_bias!(q_full, @b_q)
+      add_bias!(k_full, @b_k)
+      add_bias!(v_full, @b_v)
 
       output = SimpleMatrix.new(seq_len, @d_model)
       heads_per_kv = @num_heads // @num_kv_heads
@@ -199,6 +212,10 @@ module SHAInet
       q_full = gpu_matmul(x, @w_q)
       k_new = gpu_matmul(x, @w_k)
       v_new = gpu_matmul(x, @w_v)
+      # Qwen2-style projection biases (no-op when unset, i.e. LLaMA).
+      add_bias!(q_full, @b_q)
+      add_bias!(k_new, @b_k)
+      add_bias!(v_new, @b_v)
 
       # Apply RoPE to new K at insert time (HF half-split), then append to cache.
       half = head_dim // 2
@@ -481,6 +498,9 @@ module SHAInet
       q_full.sync_from_device!("attn_q") if q_full.device_dirty?
       k_full.sync_from_device!("attn_k") if k_full.device_dirty?
       v_full.sync_from_device!("attn_v") if v_full.device_dirty?
+      add_bias!(q_full, @b_q)
+      add_bias!(k_full, @b_k)
+      add_bias!(v_full, @b_v)
 
       output = SimpleMatrix.new(seq_len, @d_model)
       heads_per_kv = @num_heads // @num_kv_heads
@@ -511,6 +531,31 @@ module SHAInet
       seq_len.times { |i| @d_model.times { |j| result[i, j] = output[i, j] } }
       result.sync_to_device!("attn_concat")
       result * @w_o.as(CudaMatrix)
+    end
+
+    # --- Helper: add a per-column bias vector to every row, in-place (host) ---
+    private def add_bias!(m : SimpleMatrix, b : Array(Float32)?)
+      return unless b
+      bp = b.to_unsafe
+      data = m.data.to_unsafe
+      cols = m.cols
+      r = 0
+      while r < m.rows
+        base = r * cols
+        c = 0
+        while c < cols
+          data[base + c] += bp[c]
+          c += 1
+        end
+        r += 1
+      end
+    end
+
+    # CudaMatrix variant: used by the full-sequence GPU path after the
+    # projection result has been synced back to host for per-head processing.
+    private def add_bias!(m : CudaMatrix, b : Array(Float32)?)
+      return unless b
+      m.rows.times { |r| m.cols.times { |c| m[r, c] = (m[r, c].to_f32 + b[c]) } }
     end
 
     # --- Helper: extract head slice ---


### PR DESCRIPTION
Adds **Qwen2 / Qwen2.5** inference through the existing `Network#run` path — no new engine, no code outside the standard lib. Qwen2 is LLaMA-shaped but adds a bias on the q/k/v projections; that was the only missing piece.

### Library
- `LlamaBlock`: optional host-side fp32 `b_q`/`b_k`/`b_v`, added to the projection output **before RoPE** in all three attention paths (cached/decode, full-CPU, full-GPU). Works uniformly on fp32, CUDA, and **Q8** weights (bias stays fp32, applied post-GEMV). `nil` = LLaMA default → no-op, byte-identical behaviour.
- `HFLoader`: reads `self_attn.{q,k,v}_proj.bias` when present; `model_type: "qwen2"` dispatches to `load_llama`; added to `SUPPORTED_MODELS`. Tied embeddings already handled.

### Example
- `llama_chat`: ChatML (`<|im_start|>`/`<|im_end|>`) template alongside LLaMA 3, generic stop-token detection, loads via `HFLoader.load` (model_type dispatch).

### Build script (separate commit)
- `build_cuda_kernels.sh` hardcoded `-arch=sm_60` (removed in CUDA 12+) and `/usr/local/cuda`. Now auto-detects compute capability (nvidia-smi) and toolkit prefix (nvcc), both env-overridable. Fixes the `Unsupported gpu architecture 'sm_60'` failure on modern toolkits.

### Verified
- Qwen2.5-0.5B-Instruct coherent via `net.run` on **CPU** and **GPU Q8** ("The capital of France is Paris.", ~97 tok/s GPU).
- LLaMA 3.2 1B output **byte-identical** (no regression).
- New `spec/llama_qkv_bias_spec.cr`: nil-bias == zero-bias, non-zero bias shifts output.
- 161 specs pass; both builds compile with/without `-Denable_cuda`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>