### PR TITLE
feat: sharded safetensors + 64-bit CudaMatrix sizes + streaming Q8 load (re-land #120)

### DIFF
--- a/examples/llama_chat.cr
+++ b/examples/llama_chat.cr
@@ -9,19 +9,43 @@ require "json"
 #   crystal run examples/llama_chat.cr -- unsloth/Llama-3.2-1B-Instruct 512
 
 DEFAULT_REPO = "unsloth/Llama-3.2-1B-Instruct"
-MODEL_FILES  = {"config.json", "model.safetensors", "tokenizer.json"}
 
 def download_model(model_dir : String, repo : String)
   Dir.mkdir_p(model_dir)
   base_url = "https://huggingface.co/#{repo}/resolve/main"
-  MODEL_FILES.each do |file|
+
+  fetch = ->(file : String, required : Bool) : Bool {
     path = File.join(model_dir, file)
-    next if File.exists?(path) && File.size(path) > 0
+    return true if File.exists?(path) && File.size(path) > 0
     STDERR.puts "  Downloading #{file}..."
     status = Process.run("curl", ["-fL", "--progress-bar", "#{base_url}/#{file}", "-o", path],
       output: Process::Redirect::Inherit, error: Process::Redirect::Inherit)
-    raise "Failed to download #{file} from #{repo}" unless status.success?
-  end
+    File.delete(path) if !status.success? && File.exists?(path)
+    raise "Failed to download #{file} from #{repo}" if required && !status.success?
+    status.success?
+  }
+
+  fetch.call("config.json", true)
+  fetch.call("tokenizer.json", true)
+
+  # Weights: single model.safetensors if it exists, otherwise the sharded set
+  # described by model.safetensors.index.json.
+  return if fetch.call("model.safetensors", false)
+  fetch.call("model.safetensors.index.json", true)
+  index = JSON.parse(File.read(File.join(model_dir, "model.safetensors.index.json")))
+  shards = index["weight_map"].as_h.values.map(&.as_s).uniq!
+  STDERR.puts "  Sharded model: #{shards.size} shard(s)"
+  shards.each { |shard| fetch.call(shard, true) }
+end
+
+def model_complete?(dir : String) : Bool
+  single = File.join(dir, "model.safetensors")
+  return true if File.exists?(single) && File.size(single) > 0
+  index = File.join(dir, "model.safetensors.index.json")
+  return false unless File.exists?(index) && File.size(index) > 0
+  # Sharded: every shard named in the index must exist and be non-empty.
+  shards = JSON.parse(File.read(index))["weight_map"].as_h.values.map(&.as_s).uniq!
+  shards.all? { |s| (p = File.join(dir, s)) && File.exists?(p) && File.size(p) > 0 }
 end
 
 arg = ARGV[0]?
@@ -33,7 +57,9 @@ model_dir =
   else
     repo = arg || DEFAULT_REPO
     dir = File.join(Dir.tempdir, "shainet_" + repo.gsub("/", "_"))
-    unless File.exists?(File.join(dir, "model.safetensors"))
+    # download_model is idempotent (it skips already-complete files), so calling
+    # it whenever the model is incomplete self-heals partial/interrupted runs.
+    unless model_complete?(dir)
       STDERR.puts "Downloading #{repo}..."
       download_model(dir, repo)
     end
@@ -43,7 +69,10 @@ model_dir =
 # --- Load model ---
 STDERR.puts "Loading model from #{model_dir}..."
 t = Time.instant
-net = SHAInet::HFLoader.load(model_dir)
+# Stream-quantize to Q8 during load (CUDA only, unless SHAINET_FP32=1) so large
+# models never materialize their full fp32 weights in host RAM at once.
+quantize = SHAInet::CUDA.fully_available? && !ENV["SHAINET_FP32"]?
+net = SHAInet::HFLoader.load(model_dir, quantize: quantize)
 STDERR.puts "Model loaded in #{(Time.instant - t).total_seconds.round(1)}s"
 STDERR.puts "  Layers: #{net.transformer_layers.size}, d_model: #{net.transformer_layers.first.as(SHAInet::LlamaBlock).d_model}"
 
@@ -59,8 +88,7 @@ if SHAInet::CUDA.fully_available?
     STDERR.puts "Moving to GPU (fp32)..."
     net.transformer_layers.each { |l| l.as(SHAInet::LlamaBlock).to_gpu! }
   else
-    STDERR.puts "Quantizing weights to Q8 (set SHAINET_FP32=1 to keep fp32)..."
-    net.quantize!
+    # Weights were already stream-quantized to Q8 during load.
     if info = SHAInet::CUDA.memory_info
       STDERR.puts "  VRAM in use: #{((info[:total] - info[:free]) / 1024.0 / 1024.0).round(1)} MB"
     end

--- a/examples/q8_eval.cr
+++ b/examples/q8_eval.cr
@@ -41,23 +41,20 @@ model_dir =
   end
 
 STDERR.puts "Loading model from #{model_dir} (mode=#{mode})..."
-net = SHAInet::HFLoader.load_llama(model_dir)
+net = SHAInet::HFLoader.load_llama(model_dir, quantize: SHAInet::CUDA.fully_available? && mode == "q8")
 tokenizer = SHAInet::BPETokenizer.from_hf(File.join(model_dir, "tokenizer.json"))
 
 net.use_kv_cache = true
 if SHAInet::CUDA.fully_available?
-  free_before = (SHAInet::CUDA.memory_info.try &.[:free]) || 0_u64
   if mode == "q8"
-    STDERR.puts "Quantizing weights to Q8..."
-    net.quantize!
+    STDERR.puts "Weights stream-quantized to Q8 during load."
   else
     STDERR.puts "Moving to GPU (fp32)..."
     net.transformer_layers.each { |l| l.as(SHAInet::LlamaBlock).to_gpu! }
   end
   if info = SHAInet::CUDA.memory_info
     used = (info[:total] - info[:free]) / 1024.0 / 1024.0
-    weight_vram = (free_before - info[:free]) / 1024.0 / 1024.0
-    STDERR.puts "VRAM total in use: #{used.round(1)} MB | weights allocated by move: #{weight_vram.round(1)} MB"
+    STDERR.puts "VRAM total in use: #{used.round(1)} MB"
   end
 end
 

--- a/spec/sharded_safetensors_spec.cr
+++ b/spec/sharded_safetensors_spec.cr
@@ -1,0 +1,126 @@
+require "./spec_helper"
+require "json"
+require "file_utils"
+
+# Write a minimal single-file safetensors with the given 1-D F32 tensors.
+# Format: [8-byte u64 LE header size][JSON header][raw little-endian F32 data].
+private def write_safetensors(path : String, tensors : Hash(String, Array(Float32)))
+  data = IO::Memory.new
+  offsets = {} of String => Tuple(Int64, Int64)
+  tensors.each do |name, vals|
+    start = data.size.to_i64
+    vals.each { |v| data.write_bytes(v, IO::ByteFormat::LittleEndian) }
+    offsets[name] = {start, data.size.to_i64}
+  end
+
+  header = JSON.build do |j|
+    j.object do
+      tensors.each do |name, vals|
+        j.field(name) do
+          j.object do
+            j.field("dtype", "F32")
+            j.field("shape") { j.array { j.number(vals.size) } }
+            j.field("data_offsets") { j.array { off = offsets[name]; j.number(off[0]); j.number(off[1]) } }
+          end
+        end
+      end
+    end
+  end
+
+  File.open(path, "wb") do |f|
+    hbytes = header.to_slice
+    f.write_bytes(hbytes.size.to_u64, IO::ByteFormat::LittleEndian)
+    f.write(hbytes)
+    f.write(data.to_slice)
+  end
+end
+
+describe SHAInet::SafeTensors::ShardedFile do
+  it "routes each tensor read to the shard that owns it" do
+    dir = File.tempname("shards")
+    Dir.mkdir_p(dir)
+    begin
+      write_safetensors(File.join(dir, "model-00001-of-00002.safetensors"), {"a" => [1.0_f32, 2.0_f32, 3.0_f32]})
+      write_safetensors(File.join(dir, "model-00002-of-00002.safetensors"), {"b" => [4.0_f32, 5.0_f32]})
+      index = {
+        "metadata"   => {"total_size" => 20},
+        "weight_map" => {
+          "a" => "model-00001-of-00002.safetensors",
+          "b" => "model-00002-of-00002.safetensors",
+        },
+      }
+      idx_path = File.join(dir, "model.safetensors.index.json")
+      File.write(idx_path, index.to_json)
+
+      sf = SHAInet::SafeTensors::ShardedFile.new(dir, idx_path)
+      begin
+        sf.has_tensor?("a").should be_true
+        sf.has_tensor?("b").should be_true
+        sf.has_tensor?("missing").should be_false
+        sf.tensor_names.sort.should eq(["a", "b"])
+
+        sf.read_f32("a").should eq([1.0_f32, 2.0_f32, 3.0_f32])
+        sf.read_f32("b").should eq([4.0_f32, 5.0_f32])
+
+        ma = sf.read_matrix("a")
+        ma.rows.should eq(1)
+        ma.cols.should eq(3)
+        ma[0, 2].should eq(3.0_f32)
+      ensure
+        sf.close
+      end
+    ensure
+      FileUtils.rm_rf(dir)
+    end
+  end
+end
+
+describe "SHAInet::HFLoader.open_safetensors" do
+  it "selects a single-file File when model.safetensors exists" do
+    dir = File.tempname("single")
+    Dir.mkdir_p(dir)
+    begin
+      write_safetensors(File.join(dir, "model.safetensors"), {"w" => [7.0_f32]})
+      sf = SHAInet::HFLoader.open_safetensors(dir)
+      begin
+        sf.should be_a(SHAInet::SafeTensors::File)
+        sf.read_f32("w").should eq([7.0_f32])
+      ensure
+        sf.close
+      end
+    ensure
+      FileUtils.rm_rf(dir)
+    end
+  end
+
+  it "selects a ShardedFile when only an index is present" do
+    dir = File.tempname("sharded")
+    Dir.mkdir_p(dir)
+    begin
+      write_safetensors(File.join(dir, "model-00001-of-00001.safetensors"), {"w" => [8.0_f32, 9.0_f32]})
+      File.write(File.join(dir, "model.safetensors.index.json"),
+        {"weight_map" => {"w" => "model-00001-of-00001.safetensors"}}.to_json)
+      sf = SHAInet::HFLoader.open_safetensors(dir)
+      begin
+        sf.should be_a(SHAInet::SafeTensors::ShardedFile)
+        sf.read_f32("w").should eq([8.0_f32, 9.0_f32])
+      ensure
+        sf.close
+      end
+    ensure
+      FileUtils.rm_rf(dir)
+    end
+  end
+
+  it "raises when no weights are present" do
+    dir = File.tempname("empty")
+    Dir.mkdir_p(dir)
+    begin
+      expect_raises(Exception, /No model.safetensors/) do
+        SHAInet::HFLoader.open_safetensors(dir)
+      end
+    ensure
+      FileUtils.rm_rf(dir)
+    end
+  end
+end

--- a/src/shainet/hf_loader.cr
+++ b/src/shainet/hf_loader.cr
@@ -7,8 +7,25 @@ module SHAInet
   module HFLoader
     SUPPORTED_MODELS = ["gpt2", "llama", "mistral", "qwen2"]
 
+    # Open a model's weights whether they're a single model.safetensors or
+    # sharded (model.safetensors.index.json + model-0000k-of-0000N.safetensors).
+    # Returns either a SafeTensors::File or ShardedFile — both expose the same
+    # read_matrix / read_f32 / read_f64 / has_tensor? / tensor_names interface
+    # used by the loaders.
+    def self.open_safetensors(model_dir : String) : SafeTensors::File | SafeTensors::ShardedFile
+      single = ::File.join(model_dir, "model.safetensors")
+      index = ::File.join(model_dir, "model.safetensors.index.json")
+      if ::File.exists?(single)
+        SafeTensors::File.new(single)
+      elsif ::File.exists?(index)
+        SafeTensors::ShardedFile.new(model_dir, index)
+      else
+        raise "No model.safetensors or model.safetensors.index.json found in #{model_dir}"
+      end
+    end
+
     # Generic entry point — reads config.json and dispatches to the right loader.
-    def self.load(model_dir : String) : Network
+    def self.load(model_dir : String, quantize : Bool = false) : Network
       config_path = ::File.join(model_dir, "config.json")
       raise "config.json not found in #{model_dir}" unless ::File.exists?(config_path)
 
@@ -19,7 +36,7 @@ module SHAInet
       when "gpt2"
         load_gpt2(model_dir)
       when "llama", "mistral", "qwen2"
-        load_llama(model_dir)
+        load_llama(model_dir, quantize: quantize)
       else
         raise "Unsupported model_type: '#{model_type}'. Supported: #{SUPPORTED_MODELS.join(", ")}"
       end
@@ -236,16 +253,20 @@ module SHAInet
       end
     end
 
-    # Load LLaMA/Mistral model from SafeTensors.
-    def self.load_llama(model_dir : String) : Network
+    # Load LLaMA/Mistral/Qwen2 model from SafeTensors.
+    #
+    # When `quantize` is true (and CUDA is available) each transformer block is
+    # quantized to Q8 *immediately after its weights are read*, so the fp32
+    # copies are freed before the next layer loads. This keeps host memory
+    # bounded (a few GB) instead of materializing the entire fp32 model at once
+    # (~28 GB for a 7B), which lets large models load on modest-RAM machines.
+    def self.load_llama(model_dir : String, quantize : Bool = false) : Network
       config_path = ::File.join(model_dir, "config.json")
-      model_path = ::File.join(model_dir, "model.safetensors")
-
       raise "config.json not found in #{model_dir}" unless ::File.exists?(config_path)
-      raise "model.safetensors not found in #{model_dir}" unless ::File.exists?(model_path)
 
+      do_quant = quantize && CUDA.fully_available?
       config = load_llama_config(config_path)
-      sf = SafeTensors::File.new(model_path)
+      sf = open_safetensors(model_dir)
 
       begin
         d = config.hidden_size
@@ -271,6 +292,9 @@ module SHAInet
         config.vocab_size.times do |i|
           d.times { |j| emb_layer.embeddings[i, j] = embed[i, j] }
         end
+        # Reclaim the embedding read transients before the layer loop begins
+        # (the bf16->f32 conversion buffer is large for big-vocab models).
+        GC.collect if do_quant
 
         # Load transformer blocks
         config.num_hidden_layers.times do |idx|
@@ -305,6 +329,16 @@ module SHAInet
             block.b_k = sf.read_f32("#{prefix}.self_attn.k_proj.bias")
             block.b_v = sf.read_f32("#{prefix}.self_attn.v_proj.bias")
           end
+
+          # Quantize this block now so its fp32 weights can be freed before the
+          # next layer is read (bounds peak host memory for large models). Force
+          # a collection so the just-replaced fp32 SimpleMatrices + read/transpose
+          # transients are reclaimed before the next layer allocates — otherwise
+          # GC lag lets ~28 layers of fp32 garbage pile up and OOM a big model.
+          if do_quant
+            block.to_gpu!(quantize: true)
+            GC.collect
+          end
         end
 
         # Output head
@@ -321,6 +355,11 @@ module SHAInet
           output_layer.weights = sf.read_matrix("lm_head.weight").transpose
         end
         output_layer.biases = SimpleMatrix.new(1, config.vocab_size)
+
+        # Quantize the lm_head (and idempotently re-confirm the already-Q8
+        # blocks) + set the quantized-weights flag. Blocks were quantized inline
+        # above, so this only materializes the lm_head fp32 transiently.
+        net.quantize! if do_quant
 
         net
       ensure

--- a/src/shainet/math/cuda_matrix.cr
+++ b/src/shainet/math/cuda_matrix.cr
@@ -124,7 +124,7 @@ module SHAInet
       raise RuntimeError.new("CudaMatrix requires CUDA to be available") unless CUDA.fully_available?
       # Print the most frequent allocation sites
       size = @rows * @cols
-      bytes = (size * 4).to_u64
+      bytes = size.to_u64 * 4_u64
 
       # Check if we would exceed memory limits or are getting close
       if @@total_gpu_memory_allocated + bytes > @@max_gpu_memory ||
@@ -282,7 +282,7 @@ module SHAInet
 
       begin
         size = @rows * @cols
-        bytes = (size * 4).to_u64
+        bytes = size.to_u64 * 4_u64
 
         # Track sync operations for performance monitoring
         @@sync_to_device_count += 1
@@ -313,7 +313,7 @@ module SHAInet
 
       begin
         size = @rows * @cols
-        bytes = (size * 4).to_u64
+        bytes = size.to_u64 * 4_u64
 
         # Track sync operations for performance monitoring
         @@sync_from_device_count += 1
@@ -495,7 +495,7 @@ module SHAInet
       # If we have GPU data, copy it directly on GPU
       if device_dirty?
         # GPU -> GPU copy
-        bytes = (@rows * @cols * 4).to_u64
+        bytes = @rows.to_u64 * @cols.to_u64 * 4_u64
         result = CUDA.memcpy(dptr.as(Pointer(Void)), sptr.as(Pointer(Void)), bytes, CUDA::MemcpyKind::DeviceToDevice)
         raise RuntimeError.new("GPU-to-GPU memcpy failed") if result != 0
 
@@ -758,7 +758,7 @@ module SHAInet
       other.sync_to_device!("copy_from") unless other.device_dirty?
 
       # GPU -> GPU copy
-      bytes = (@rows * @cols * 4).to_u64
+      bytes = @rows.to_u64 * @cols.to_u64 * 4_u64
       result = CUDA.memcpy(dptr.as(Pointer(Void)), sptr.as(Pointer(Void)), bytes, CUDA::MemcpyKind::DeviceToDevice)
       raise RuntimeError.new("GPU-to-GPU memcpy failed") if result != 0
 

--- a/src/shainet/math/gpu_memory.cr
+++ b/src/shainet/math/gpu_memory.cr
@@ -32,7 +32,7 @@ module SHAInet
       size = rows * cols
       count.times do
         ptr = Pointer(Float32).null
-        bytes = ((size) * 4).to_u64
+        bytes = size.to_u64 * 4_u64
         res = CUDA.malloc(pointerof(ptr).as(Pointer(Pointer(Void))), bytes)
         next unless res == 0
         @@pool[size] << ptr
@@ -67,7 +67,7 @@ module SHAInet
       raise ArgumentError.new("size mismatch") unless src.rows == dest.rows && src.cols == dest.cols
 
       size = src.rows * src.cols
-      bytes = (size * 4).to_u64
+      bytes = size.to_u64 * 4_u64
 
       # Keep CPU copy in sync
       dest_slice = Slice(Float32).new(dest.raw_data.to_unsafe, size)
@@ -91,7 +91,7 @@ module SHAInet
       raise ArgumentError.new("size mismatch") unless matrix.rows == dest.rows && matrix.cols == dest.cols
 
       size = matrix.rows * matrix.cols
-      bytes = (size * 4).to_u64
+      bytes = size.to_u64 * 4_u64
 
       # Direct copy F32 → F32
       dest.raw_data.to_unsafe.copy_from(matrix.data.to_unsafe, size)
@@ -116,7 +116,7 @@ module SHAInet
       dest_slice.copy_from(slice)
 
       if (dptr = dest.device_ptr) && !dptr.null?
-        bytes = (array.size * 4).to_u64
+        bytes = array.size.to_u64 * 4_u64
         result = CUDA.memcpy(dptr.as(Pointer(Void)), slice.to_unsafe.as(Pointer(Void)), bytes, CUDA::MemcpyKind::HostToDevice)
         Log.error { "GPUMemory.to_gpu!: GPU memcpy failed with result #{result}" } if result != 0
       end
@@ -143,7 +143,7 @@ module SHAInet
       dest_slice.copy_from(src_slice)
 
       if (dptr = dest.device_ptr) && !dptr.null?
-        bytes = (rows * cols * 4).to_u64
+        bytes = rows.to_u64 * cols.to_u64 * 4_u64
         result = CUDA.memcpy(dptr.as(Pointer(Void)), src_slice.to_unsafe.as(Pointer(Void)), bytes, CUDA::MemcpyKind::HostToDevice)
         Log.error { "GPUMemory.to_gpu!: GPU memcpy failed with result #{result}" } if result != 0
       end

--- a/src/shainet/safetensors.cr
+++ b/src/shainet/safetensors.cr
@@ -223,5 +223,50 @@ module SHAInet
         pointerof(f32_bits).as(Pointer(Float32)).value
       end
     end
+
+    # A model split across multiple .safetensors shards (large models ship as
+    # model-00001-of-0000N.safetensors + a model.safetensors.index.json whose
+    # "weight_map" maps each tensor name to its shard file). Presents the same
+    # read interface as File, routing each tensor read to the owning shard.
+    class ShardedFile
+      @shards : Hash(String, File)        # shard filename -> open File
+      @owner : Hash(String, File)         # tensor name   -> owning shard File
+
+      def initialize(model_dir : String, index_path : String)
+        index = JSON.parse(::File.read(index_path))
+        weight_map = index["weight_map"].as_h
+        @shards = Hash(String, File).new
+        @owner = Hash(String, File).new
+        weight_map.each do |tensor, shard_any|
+          shard = shard_any.as_s
+          f = (@shards[shard] ||= File.new(::File.join(model_dir, shard)))
+          @owner[tensor] = f
+        end
+      end
+
+      def has_tensor?(name : String) : Bool
+        @owner.has_key?(name)
+      end
+
+      def tensor_names : Array(String)
+        @owner.keys
+      end
+
+      def read_f32(name : String) : Array(Float32)
+        (@owner[name]? || raise "Tensor '#{name}' not found in any shard").read_f32(name)
+      end
+
+      def read_f64(name : String) : Array(Float64)
+        (@owner[name]? || raise "Tensor '#{name}' not found in any shard").read_f64(name)
+      end
+
+      def read_matrix(name : String) : SimpleMatrix
+        (@owner[name]? || raise "Tensor '#{name}' not found in any shard").read_matrix(name)
+      end
+
+      def close
+        @shards.each_value(&.close)
+      end
+    end
   end
 end


### PR DESCRIPTION
**Re-lands PR #120, which got orphaned from master.** #120 was stacked on `feat/qwen2-support`; when #119 squash-merged to master, #120's base was never retargeted, so #120 merged into `feat/qwen2-support` instead of master and its changes never reached master. This is the same squashed #120 commit cherry-picked cleanly onto current master.

Contents (all reviewed & approved in #120):
- **Int32 byte-size overflow fix** (`cuda_matrix.cr` + `gpu_memory.cr`): cast to `UInt64` before `*4` so >2.15 GB tensors don't overflow (e.g. Qwen2.5-7B's 2.18 GB embedding).
- **Sharded safetensors** (`SafeTensors::ShardedFile` + `HFLoader.open_safetensors`): load multi-file models via `model.safetensors.index.json`.
- **Streaming quantized load** (`load(quantize:)`): quantize each block as it's read (+ per-layer GC) so large models don't materialize the full fp32 model in RAM.
- Examples updated; `spec/sharded_safetensors_spec.cr` added.

Verified after cherry-pick onto master: 165 specs pass; both builds compile.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>