### PR TITLE
feat: Mixture-of-Experts FFN (MoEFF) — first brick for qwen3_moe

### DIFF
--- a/spec/moe_ff_spec.cr
+++ b/spec/moe_ff_spec.cr
@@ -1,0 +1,115 @@
+require "./spec_helper"
+
+# Build a SwiGLU expert with deterministic, distinct weights (so each expert
+# produces a different output and we can verify the combine).
+private def fill_expert(ex : SHAInet::SwiGLUFF, d_model : Int32, ff : Int32, seed : Float64)
+  g = SHAInet::SimpleMatrix.new(d_model, ff)
+  u = SHAInet::SimpleMatrix.new(d_model, ff)
+  dn = SHAInet::SimpleMatrix.new(ff, d_model)
+  d_model.times { |r| ff.times { |c| g[r, c] = 0.05 * (r + 1) + 0.01 * c + seed } }
+  d_model.times { |r| ff.times { |c| u[r, c] = 0.03 * (c + 1) - 0.02 * r + seed } }
+  ff.times { |r| d_model.times { |c| dn[r, c] = 0.04 * (r + 1) + 0.02 * c - seed } }
+  ex.gate_proj = g
+  ex.up_proj = u
+  ex.down_proj = dn
+end
+
+# Router that makes logit(expert e) == column-sum of router[:, e] when the input
+# row is all ones. We put the whole logit in row 0 and zero the rest.
+private def router_with_logits(d_model : Int32, logits : Array(Float64)) : SHAInet::SimpleMatrix
+  r = SHAInet::SimpleMatrix.new(d_model, logits.size)
+  logits.each_with_index { |v, e| r[0, e] = v }
+  r
+end
+
+describe SHAInet::MoEFF do
+  it "selects the top-k experts and combines with renormalized softmax weights" do
+    d_model = 4
+    ff = 3
+    ne = 4
+    moe = SHAInet::MoEFF.new(d_model, ff, ne, 2, norm_topk_prob: true)
+
+    # logits: e0=0, e1=2, e2=-5, e3=4  -> top-2 are e3 and e1
+    moe.router = router_with_logits(d_model, [0.0, 2.0, -5.0, 4.0])
+    moe.experts.each_with_index { |ex, i| fill_expert(ex, d_model, ff, 0.1 * (i + 1)) }
+
+    x = SHAInet::SimpleMatrix.new(1, d_model)
+    d_model.times { |c| x[0, c] = 1.0 }
+
+    # Renormalized weights over the two selected experts.
+    e3 = Math.exp(4.0); e1 = Math.exp(2.0); denom = e3 + e1
+    w3 = e3 / denom; w1 = e1 / denom
+
+    ref3 = moe.experts[3].forward(x)
+    ref1 = moe.experts[1].forward(x)
+
+    out = moe.forward(x)
+    out.rows.should eq(1)
+    out.cols.should eq(d_model)
+    d_model.times do |c|
+      expected = w3 * ref3[0, c] + w1 * ref1[0, c]
+      out[0, c].should be_close(expected, 1e-5)
+    end
+  end
+
+  it "uses raw (un-renormalized) softmax weights when norm_topk_prob is false" do
+    d_model = 4
+    ff = 3
+    ne = 4
+    moe = SHAInet::MoEFF.new(d_model, ff, ne, 2, norm_topk_prob: false)
+    logits = [0.0, 2.0, -5.0, 4.0]
+    moe.router = router_with_logits(d_model, logits)
+    moe.experts.each_with_index { |ex, i| fill_expert(ex, d_model, ff, 0.1 * (i + 1)) }
+
+    x = SHAInet::SimpleMatrix.new(1, d_model)
+    d_model.times { |c| x[0, c] = 1.0 }
+
+    z = logits.sum { |l| Math.exp(l) } # full-softmax denominator
+    w3 = Math.exp(4.0) / z
+    w1 = Math.exp(2.0) / z
+
+    ref3 = moe.experts[3].forward(x)
+    ref1 = moe.experts[1].forward(x)
+
+    out = moe.forward(x)
+    d_model.times do |c|
+      expected = w3 * ref3[0, c] + w1 * ref1[0, c]
+      out[0, c].should be_close(expected, 1e-5)
+    end
+  end
+
+  it "routes each token in a batch independently" do
+    d_model = 4
+    ff = 3
+    ne = 3
+    moe = SHAInet::MoEFF.new(d_model, ff, ne, 1, norm_topk_prob: true)
+    moe.experts.each_with_index { |ex, i| fill_expert(ex, d_model, ff, 0.2 * (i + 1)) }
+
+    # Router favors expert 0 for [1,0,..] inputs and expert 2 for [0,..,1].
+    r = SHAInet::SimpleMatrix.new(d_model, ne)
+    r[0, 0] = 10.0 # row-0 feature -> expert 0
+    r[d_model - 1, 2] = 10.0 # last feature -> expert 2
+    moe.router = r
+
+    x = SHAInet::SimpleMatrix.new(2, d_model)
+    x[0, 0] = 1.0          # token 0 -> expert 0
+    x[1, d_model - 1] = 1.0 # token 1 -> expert 2
+
+    row0 = SHAInet::SimpleMatrix.new(1, d_model); row0[0, 0] = 1.0
+    row1 = SHAInet::SimpleMatrix.new(1, d_model); row1[0, d_model - 1] = 1.0
+    ref0 = moe.experts[0].forward(row0) # top_k=1, weight renorm -> 1.0
+    ref2 = moe.experts[2].forward(row1)
+
+    out = moe.forward(x)
+    out.rows.should eq(2)
+    d_model.times do |c|
+      out[0, c].should be_close(ref0[0, c], 1e-5)
+      out[1, c].should be_close(ref2[0, c], 1e-5)
+    end
+  end
+
+  it "rejects an invalid top_k" do
+    expect_raises(ArgumentError) { SHAInet::MoEFF.new(4, 3, 4, 0) }
+    expect_raises(ArgumentError) { SHAInet::MoEFF.new(4, 3, 4, 5) }
+  end
+end

--- a/src/shainet.cr
+++ b/src/shainet.cr
@@ -46,6 +46,7 @@ require "./shainet/transformer/positionwise_ff"
 require "./shainet/transformer/rms_norm"
 require "./shainet/transformer/rope"
 require "./shainet/transformer/swiglu_ff"
+require "./shainet/transformer/moe_ff"
 require "./shainet/transformer/transformer_block"
 require "./shainet/version"
 

--- a/src/shainet/transformer/moe_ff.cr
+++ b/src/shainet/transformer/moe_ff.cr
@@ -1,0 +1,98 @@
+require "./swiglu_ff"
+
+module SHAInet
+  # Mixture-of-Experts feed-forward, Qwen3-MoE style.
+  #
+  # A small router projects each token to `num_experts` logits; the top-`top_k`
+  # experts (by softmax weight) are evaluated and their outputs combined as a
+  # weighted sum. Each expert is a SwiGLU FFN (see SwiGLUFF). Only `top_k` of
+  # `num_experts` experts run per token, so a 128-expert / top-8 layer does the
+  # work of ~8 dense FFNs while holding all 128 in memory.
+  #
+  # The router is kept in full precision (it is tiny and routing is sensitive to
+  # quantization error); experts are quantizable to Q8/Q4 like any other weight.
+  class MoEFF
+    getter experts : Array(SwiGLUFF)
+    property router : SimpleMatrix | CudaMatrix # [d_model, num_experts]
+    getter num_experts : Int32
+    getter top_k : Int32
+    getter norm_topk_prob : Bool
+    getter d_model : Int32
+
+    def initialize(@d_model : Int32, ff_hidden : Int32, @num_experts : Int32,
+                   @top_k : Int32, @norm_topk_prob : Bool = true)
+      raise ArgumentError.new("num_experts must be positive") unless @num_experts > 0
+      raise ArgumentError.new("top_k must be in 1..num_experts") unless 1 <= @top_k <= @num_experts
+      @router = SimpleMatrix.new(@d_model, @num_experts)
+      @experts = Array(SwiGLUFF).new(@num_experts) { SwiGLUFF.new(@d_model, ff_hidden) }
+    end
+
+    def to_gpu!(quantize : Bool = false, bits : Int32 = 8)
+      return unless CUDA.fully_available?
+      # Router stays full precision (CudaMatrix); only experts are quantized.
+      @router = @router.as(SimpleMatrix).to_cuda if @router.is_a?(SimpleMatrix)
+      @experts.each(&.to_gpu!(quantize, bits))
+    end
+
+    # Router logits [tokens, num_experts] for the given activations.
+    private def router_logits(x : SimpleMatrix) : SimpleMatrix
+      r = @router
+      if r.is_a?(CudaMatrix)
+        xg = x.to_cuda
+        (xg * r).to_simple
+      else
+        x * r.as(SimpleMatrix)
+      end
+    end
+
+    # Top-k (expert_index, weight) for row `t`: softmax over all experts, take
+    # the top-k by probability, then (when norm_topk_prob) renormalize the
+    # selected weights so they sum to 1 — matching the Qwen3-MoE router.
+    private def top_k_gating(logits : SimpleMatrix, t : Int32) : Array(Tuple(Int32, Float64))
+      ne = @num_experts
+      maxl = -Float64::INFINITY
+      ne.times { |e| v = logits[t, e].to_f64; maxl = v if v > maxl }
+      sum = 0.0
+      probs = Array(Float64).new(ne) do |e|
+        p = Math.exp(logits[t, e].to_f64 - maxl)
+        sum += p
+        p
+      end
+      probs.map! { |p| p / sum }
+
+      idxs = (0...ne).to_a.sort_by! { |e| -probs[e] }[0, @top_k]
+      sel = idxs.map { |e| {e, probs[e]} }
+      if @norm_topk_prob
+        wsum = sel.sum { |pair| pair[1] }
+        wsum = 1.0 if wsum == 0.0
+        sel = sel.map { |pair| {pair[0], pair[1] / wsum} }
+      end
+      sel
+    end
+
+    # CPU / quantized path. Each token is routed independently; selected experts
+    # run via SwiGLUFF#forward (which itself dispatches to GPU gemv when its
+    # weights are quantized), and their outputs are summed with the gate weights.
+    def forward(x : SimpleMatrix) : SimpleMatrix
+      logits = router_logits(x)
+      out = SimpleMatrix.zeros(x.rows, @d_model)
+      row = SimpleMatrix.new(1, @d_model)
+      x.rows.times do |t|
+        gating = top_k_gating(logits, t)
+        @d_model.times { |c| row[0, c] = x[t, c] }
+        gating.each do |(e, w)|
+          ey = @experts[e].forward(row) # [1, d_model]
+          @d_model.times { |c| out[t, c] = out[t, c] + w * ey[0, c] }
+        end
+      end
+      out
+    end
+
+    # fp32 GPU path. Routing + expert evaluation happen through the SimpleMatrix
+    # path; convert only at the boundary.
+    def forward(x : CudaMatrix) : CudaMatrix
+      x.sync_from_device!("moe_in") if x.device_dirty?
+      forward(x.to_simple).to_cuda
+    end
+  end
+end


### PR DESCRIPTION
## Why
First brick toward running a Qwen3-MoE model (e.g. **Qwen3-Coder-30B-A3B**): the Mixture-of-Experts feed-forward. A router picks the top-k experts per token; their outputs are combined as a weighted sum. Only `top_k` of `num_experts` experts run per token, so a 128-expert/top-8 layer costs ~8 dense FFNs while holding all 128 in memory.

## What
- **`MoEFF`** (`src/shainet/transformer/moe_ff.cr`): router `[d_model, num_experts]` + `Array(SwiGLUFF)` experts.
- `forward(SimpleMatrix)`: per-token softmax over all experts → top-k → optional `norm_topk_prob` renormalization → weighted combine (matches the Qwen3-MoE router).
- `forward(CudaMatrix)`: delegates through the SimpleMatrix path (experts still hit GPU gemv when quantized).
- `to_gpu!(quantize, bits)`: experts quantize to **Q8/Q4 for free** via the existing `QuantizedWeight` interface; the **router stays full precision** (routing is sensitive to quant error).

## Tests
Hardware-independent spec (4 examples) verifying against hand-computed references:
- top-k selection + renormalized softmax combine,
- raw-softmax weights when `norm_topk_prob: false`,
- per-token independent routing across a batch,
- invalid `top_k` raises.

172 specs pass; both builds compile.

## Scope
FFN **only**. The qwen3_moe attention generalization (explicit `head_dim`, non-square Q/K/V, **QK-norm**) and the loader/wiring land in follow-up PRs — kept separate to isolate regression risk to the working LLaMA/Qwen2 attention path.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>