### PR TITLE
feat: Qwen3 attention (explicit head_dim, non-square QKV, QK-norm) + qwen3 loader

### DIFF
--- a/src/shainet/basic/network_setup.cr
+++ b/src/shainet/basic/network_setup.cr
@@ -107,7 +107,7 @@ module SHAInet
     # l_type is: :input, :hidden or :output
     # l_size = size of the layer
     # n_type = advanced option for layer types
-    def add_layer(l_type : Symbol | String, l_size : Int32, activation_function : ActivationFunction = SHAInet.sigmoid, num_heads : Int32 = 1, ff_hidden : Int32 = l_size*4, drop_percent : Int32 = 0, blocks : Int32 = 1, *, vocab_size : Int32 = 0, num_kv_heads : Int32 = num_heads, eps : Float64 = 1e-5)
+    def add_layer(l_type : Symbol | String, l_size : Int32, activation_function : ActivationFunction = SHAInet.sigmoid, num_heads : Int32 = 1, ff_hidden : Int32 = l_size*4, drop_percent : Int32 = 0, blocks : Int32 = 1, *, vocab_size : Int32 = 0, num_kv_heads : Int32 = num_heads, eps : Float64 = 1e-5, head_dim : Int32? = nil)
       if l_type.to_s == "transformer" && blocks > 1
         blocks.times do
           add_layer(l_type, l_size, activation_function, num_heads, ff_hidden, drop_percent, 1)
@@ -121,7 +121,7 @@ module SHAInet
               when "transformer"
                 TransformerLayer.new(l_size, num_heads, ff_hidden, drop_percent)
               when "llama"
-                LlamaBlock.new(l_size, num_heads, ff_hidden, eps, 10000.0, num_kv_heads)
+                LlamaBlock.new(l_size, num_heads, ff_hidden, eps, 10000.0, num_kv_heads, head_dim)
               else
                 MatrixLayer.new(l_size, activation_function)
               end

--- a/src/shainet/hf_loader.cr
+++ b/src/shainet/hf_loader.cr
@@ -279,7 +279,8 @@ module SHAInet
         eps = config.rms_norm_eps
         theta = config.rope_theta
         # Qwen3 sets head_dim explicitly (e.g. 128), independent of d/n_heads;
-        # LLaMA/Qwen2 derive it as d/n_heads.
+        # LLaMA/Qwen2 leave it nil and the block derives d/n_heads (and validates
+        # divisibility). Use a concrete value only for the local RoPE-freq calc.
         head_dim = config.head_dim || (d // n_heads)
         rope_freqs = compute_rope_freqs(config, head_dim)
 
@@ -287,7 +288,7 @@ module SHAInet
         net.add_layer(:input, 1)
         net.add_layer(:embedding, d, vocab_size: config.vocab_size)
         config.num_hidden_layers.times do
-          net.add_layer(:llama, d, num_heads: n_heads, ff_hidden: ff, num_kv_heads: config.num_key_value_heads, eps: eps, head_dim: head_dim)
+          net.add_layer(:llama, d, num_heads: n_heads, ff_hidden: ff, num_kv_heads: config.num_key_value_heads, eps: eps, head_dim: config.head_dim)
         end
         net.add_layer(:output, config.vocab_size, activation_function: SHAInet.identity)
         net.fully_connect
@@ -338,8 +339,11 @@ module SHAInet
 
           # Optional Qwen3 QK-norm weights (per-head RMSNorm over head_dim),
           # applied to Q and K before RoPE. Present for qwen3/qwen3_moe, absent
-          # for LLaMA/Qwen2. They appear as a complete pair.
-          if sf.has_tensor?("#{prefix}.self_attn.q_norm.weight")
+          # for LLaMA/Qwen2. Always a complete pair.
+          has_qn = sf.has_tensor?("#{prefix}.self_attn.q_norm.weight")
+          has_kn = sf.has_tensor?("#{prefix}.self_attn.k_norm.weight")
+          if has_qn || has_kn
+            raise "Incomplete QK-norm weights for #{prefix} (q_norm=#{has_qn} k_norm=#{has_kn})" unless has_qn && has_kn
             block.q_norm = sf.read_f32("#{prefix}.self_attn.q_norm.weight")
             block.k_norm = sf.read_f32("#{prefix}.self_attn.k_norm.weight")
           end

--- a/src/shainet/hf_loader.cr
+++ b/src/shainet/hf_loader.cr
@@ -5,7 +5,7 @@ module SHAInet
   # Load a GPT-2 model directly from a HuggingFace SafeTensors file.
   # No Python, no PyTorch — pure Crystal.
   module HFLoader
-    SUPPORTED_MODELS = ["gpt2", "llama", "mistral", "qwen2"]
+    SUPPORTED_MODELS = ["gpt2", "llama", "mistral", "qwen2", "qwen3"]
 
     # Open a model's weights whether they're a single model.safetensors or
     # sharded (model.safetensors.index.json + model-0000k-of-0000N.safetensors).
@@ -36,7 +36,7 @@ module SHAInet
       case model_type
       when "gpt2"
         load_gpt2(model_dir)
-      when "llama", "mistral", "qwen2"
+      when "llama", "mistral", "qwen2", "qwen3"
         load_llama(model_dir, quantize: quantize, bits: bits)
       else
         raise "Unsupported model_type: '#{model_type}'. Supported: #{SUPPORTED_MODELS.join(", ")}"
@@ -201,7 +201,8 @@ module SHAInet
       rope_theta : Float64,
       num_key_value_heads : Int32,
       tie_word_embeddings : Bool,
-      rope_scaling : JSON::Any?
+      rope_scaling : JSON::Any?,
+      head_dim : Int32? = nil
 
     def self.load_llama_config(path : String) : LlamaConfig
       json = JSON.parse(::File.read(path))
@@ -215,7 +216,8 @@ module SHAInet
         rope_theta: (json["rope_theta"]?.try(&.as_f) || 10000.0),
         num_key_value_heads: (json["num_key_value_heads"]?.try(&.as_i) || json["num_attention_heads"].as_i),
         tie_word_embeddings: (json["tie_word_embeddings"]?.try(&.as_bool) || false),
-        rope_scaling: json["rope_scaling"]?
+        rope_scaling: json["rope_scaling"]?,
+        head_dim: json["head_dim"]?.try(&.as_i)
       )
     end
 
@@ -276,14 +278,16 @@ module SHAInet
         n_heads = config.num_attention_heads
         eps = config.rms_norm_eps
         theta = config.rope_theta
-        head_dim = d // n_heads
+        # Qwen3 sets head_dim explicitly (e.g. 128), independent of d/n_heads;
+        # LLaMA/Qwen2 derive it as d/n_heads.
+        head_dim = config.head_dim || (d // n_heads)
         rope_freqs = compute_rope_freqs(config, head_dim)
 
         net = Network.new
         net.add_layer(:input, 1)
         net.add_layer(:embedding, d, vocab_size: config.vocab_size)
         config.num_hidden_layers.times do
-          net.add_layer(:llama, d, num_heads: n_heads, ff_hidden: ff, num_kv_heads: config.num_key_value_heads, eps: eps)
+          net.add_layer(:llama, d, num_heads: n_heads, ff_hidden: ff, num_kv_heads: config.num_key_value_heads, eps: eps, head_dim: head_dim)
         end
         net.add_layer(:output, config.vocab_size, activation_function: SHAInet.identity)
         net.fully_connect
@@ -330,6 +334,14 @@ module SHAInet
             block.b_q = sf.read_f32("#{prefix}.self_attn.q_proj.bias")
             block.b_k = sf.read_f32("#{prefix}.self_attn.k_proj.bias")
             block.b_v = sf.read_f32("#{prefix}.self_attn.v_proj.bias")
+          end
+
+          # Optional Qwen3 QK-norm weights (per-head RMSNorm over head_dim),
+          # applied to Q and K before RoPE. Present for qwen3/qwen3_moe, absent
+          # for LLaMA/Qwen2. They appear as a complete pair.
+          if sf.has_tensor?("#{prefix}.self_attn.q_norm.weight")
+            block.q_norm = sf.read_f32("#{prefix}.self_attn.q_norm.weight")
+            block.k_norm = sf.read_f32("#{prefix}.self_attn.k_norm.weight")
           end
 
           # Quantize this block now so its fp32 weights can be freed before the

--- a/src/shainet/transformer/llama_block.cr
+++ b/src/shainet/transformer/llama_block.cr
@@ -75,6 +75,7 @@ module SHAInet
       # head_dim defaults to d_model/num_heads (LLaMA/Qwen2). Qwen3 passes it
       # explicitly (e.g. 128), so q_dim = num_heads*head_dim may differ from d_model.
       if hd = head_dim
+        raise ArgumentError.new("head_dim must be positive") unless hd > 0
         @head_dim = hd
       else
         raise ArgumentError.new("d_model must be divisible by num_heads") unless @d_model % @num_heads == 0

--- a/src/shainet/transformer/llama_block.cr
+++ b/src/shainet/transformer/llama_block.cr
@@ -11,6 +11,16 @@ module SHAInet
     getter num_kv_heads : Int32
     getter head_dim : Int32
     getter d_model : Int32
+    # Total width of the concatenated query heads = num_heads * head_dim. Equals
+    # d_model for LLaMA/Qwen2, but Qwen3 uses an explicit head_dim so this can be
+    # larger (e.g. 32*128=4096 with d_model=2048). w_q is [d_model, q_dim] and
+    # w_o is [q_dim, d_model]; the per-head attention output has width q_dim.
+    getter q_dim : Int32
+    # Qwen3 QK-norm: per-head RMSNorm applied to Q and K (over head_dim) right
+    # before RoPE. nil = disabled (the LLaMA/Qwen2 default — zero overhead).
+    property q_norm : Array(Float32)? = nil
+    property k_norm : Array(Float32)? = nil
+    @qk_norm_eps : Float64 = 1e-6
     property rope_theta : Float64
     # Optional precomputed inverse frequencies (size head_dim/2). When set,
     # these override the default theta^(-2i/d) computation (used for LLaMA 3
@@ -59,19 +69,27 @@ module SHAInet
 
     def initialize(@d_model : Int32, @num_heads : Int32, ff_hidden : Int32,
                    eps : Float64 = 1e-6, @rope_theta : Float64 = 10000.0,
-                   @num_kv_heads : Int32 = @num_heads)
+                   @num_kv_heads : Int32 = @num_heads, head_dim : Int32? = nil)
       super(@d_model, SHAInet.none)
-      raise ArgumentError.new("d_model must be divisible by num_heads") unless @d_model % @num_heads == 0
       raise ArgumentError.new("num_heads must be divisible by num_kv_heads") unless @num_kv_heads > 0 && @num_heads % @num_kv_heads == 0
-      @head_dim = @d_model // @num_heads
+      # head_dim defaults to d_model/num_heads (LLaMA/Qwen2). Qwen3 passes it
+      # explicitly (e.g. 128), so q_dim = num_heads*head_dim may differ from d_model.
+      if hd = head_dim
+        @head_dim = hd
+      else
+        raise ArgumentError.new("d_model must be divisible by num_heads") unless @d_model % @num_heads == 0
+        @head_dim = @d_model // @num_heads
+      end
+      @q_dim = @num_heads * @head_dim
       kv_dim = @num_kv_heads * @head_dim
+      @qk_norm_eps = eps
       @norm1 = RMSNorm.new(@d_model, eps)
       @norm2 = RMSNorm.new(@d_model, eps)
       @ffn = SwiGLUFF.new(@d_model, ff_hidden)
-      @w_q = SimpleMatrix.new(@d_model, @d_model)
+      @w_q = SimpleMatrix.new(@d_model, @q_dim)
       @w_k = SimpleMatrix.new(@d_model, kv_dim)
       @w_v = SimpleMatrix.new(@d_model, kv_dim)
-      @w_o = SimpleMatrix.new(@d_model, @d_model)
+      @w_o = SimpleMatrix.new(@q_dim, @d_model)
       @k_cache = Array.new(@num_kv_heads) { Array(Float32).new }
       @v_cache = Array.new(@num_kv_heads) { Array(Float32).new }
     end
@@ -184,8 +202,10 @@ module SHAInet
       add_bias!(q_full, @b_q)
       add_bias!(k_full, @b_k)
       add_bias!(v_full, @b_v)
+      apply_head_rmsnorm!(q_full, @num_heads, @q_norm)
+      apply_head_rmsnorm!(k_full, @num_kv_heads, @k_norm)
 
-      output = SimpleMatrix.new(seq_len, @d_model)
+      output = SimpleMatrix.new(seq_len, @q_dim)
       heads_per_kv = @num_heads // @num_kv_heads
 
       @num_heads.times do |h|
@@ -222,6 +242,11 @@ module SHAInet
       add_bias!(q_full, @b_q)
       add_bias!(k_new, @b_k)
       add_bias!(v_new, @b_v)
+      # Qwen3 QK-norm before RoPE (no-op when unset). K is normalized here, then
+      # rotated and appended below; Q is normalized here, then rotated in the
+      # per-head attention loop.
+      apply_head_rmsnorm!(q_full, @num_heads, @q_norm)
+      apply_head_rmsnorm!(k_new, @num_kv_heads, @k_norm)
 
       # Apply RoPE to new K at insert time (HF half-split), then append to cache.
       half = head_dim // 2
@@ -247,7 +272,7 @@ module SHAInet
 
       total_len = @cache_len + new_tokens
       @cache_len = total_len
-      output = SimpleMatrix.new(new_tokens, @d_model)
+      output = SimpleMatrix.new(new_tokens, @q_dim)
 
       if gpu_attention?
         attention_heads_gpu(q_full, output, new_tokens, start_pos, total_len, scale)
@@ -266,7 +291,7 @@ module SHAInet
       heads_per_kv = @num_heads // @num_kv_heads
 
       half = head_dim // 2
-      dm = @d_model
+      dm = @q_dim
       qptr = q_full.data.to_unsafe
       optr = output.data.to_unsafe
       # Reusable scratch buffers (avoid per-head/per-token allocations).
@@ -368,7 +393,7 @@ module SHAInet
                                     new_tokens : Int32, start_pos : Int32,
                                     total_len : Int32, scale : Float32)
       head_dim = @head_dim
-      dm = @d_model
+      dm = @q_dim
       half = head_dim // 2
       heads_per_kv = @num_heads // @num_kv_heads
       chunk = new_tokens * head_dim     # floats per kv_head per tensor
@@ -507,8 +532,10 @@ module SHAInet
       add_bias!(q_full, @b_q)
       add_bias!(k_full, @b_k)
       add_bias!(v_full, @b_v)
+      apply_head_rmsnorm!(q_full, @num_heads, @q_norm)
+      apply_head_rmsnorm!(k_full, @num_kv_heads, @k_norm)
 
-      output = SimpleMatrix.new(seq_len, @d_model)
+      output = SimpleMatrix.new(seq_len, @q_dim)
       heads_per_kv = @num_heads // @num_kv_heads
 
       @num_heads.times do |h|
@@ -533,8 +560,8 @@ module SHAInet
       end
 
       # Output projection on GPU: convert to CudaMatrix, then SGEMM
-      result = CudaMatrix.new(seq_len, @d_model)
-      seq_len.times { |i| @d_model.times { |j| result[i, j] = output[i, j] } }
+      result = CudaMatrix.new(seq_len, @q_dim)
+      seq_len.times { |i| @q_dim.times { |j| result[i, j] = output[i, j] } }
       result.sync_to_device!("attn_concat")
       result * @w_o.as(CudaMatrix)
     end
@@ -564,6 +591,56 @@ module SHAInet
       return unless b
       raise ArgumentError.new("bias size #{b.size} does not match matrix cols #{m.cols}") unless b.size == m.cols
       m.rows.times { |r| m.cols.times { |c| m[r, c] = (m[r, c].to_f32 + b[c]) } }
+    end
+
+    # --- Helper: Qwen3 QK-norm. Per-head RMSNorm over head_dim with a learned
+    # weight, applied in-place to every (row, head) slice of `m`
+    # [rows, nheads*head_dim], before RoPE. No-op when `weight` is nil (the
+    # LLaMA/Qwen2 default), so existing models are byte-identical.
+    private def apply_head_rmsnorm!(m : SimpleMatrix, nheads : Int32, weight : Array(Float32)?)
+      return unless w = weight
+      hd = @head_dim
+      raise ArgumentError.new("qk_norm weight size #{w.size} != head_dim #{hd}") unless w.size == hd
+      eps = @qk_norm_eps
+      wp = w.to_unsafe
+      data = m.data.to_unsafe
+      cols = m.cols
+      m.rows.times do |r|
+        nheads.times do |h|
+          base = r * cols + h * hd
+          ss = 0.0_f32
+          d = 0
+          while d < hd
+            v = data[base + d]
+            ss += v * v
+            d += 1
+          end
+          inv = (1.0 / Math.sqrt(ss / hd + eps)).to_f32
+          d = 0
+          while d < hd
+            data[base + d] = data[base + d] * inv * wp[d]
+            d += 1
+          end
+        end
+      end
+    end
+
+    # CudaMatrix variant (full-sequence GPU path, after the projection has been
+    # synced to host for per-head processing). Operates on the host mirror.
+    private def apply_head_rmsnorm!(m : CudaMatrix, nheads : Int32, weight : Array(Float32)?)
+      return unless w = weight
+      hd = @head_dim
+      raise ArgumentError.new("qk_norm weight size #{w.size} != head_dim #{hd}") unless w.size == hd
+      eps = @qk_norm_eps
+      m.rows.times do |r|
+        nheads.times do |h|
+          col0 = h * hd
+          ss = 0.0_f32
+          hd.times { |d| v = m[r, col0 + d].to_f32; ss += v * v }
+          inv = (1.0 / Math.sqrt(ss / hd + eps)).to_f32
+          hd.times { |d| m[r, col0 + d] = (m[r, col0 + d].to_f32 * inv * w[d]) }
+        end
+      end
     end
 
     # --- Helper: extract head slice ---


### PR DESCRIPTION
## Why
Second brick toward Qwen3-MoE: make the attention block handle the **Qwen3** architecture, and add the dense `qwen3` loader. All changes are additive + default-off, so LLaMA/Qwen2 stays **byte-identical**.

## What
- **Explicit `head_dim`** — defaults to `d_model/num_heads` (LLaMA/Qwen2); Qwen3 sets it directly (e.g. 128), so `q_dim = num_heads*head_dim` can differ from `d_model`. `w_q` is now `[d_model, q_dim]`, `w_o` is `[q_dim, d_model]` (**non-square**), and every attention path (full CPU/GPU, cached CPU, GPU head loop) strides by `q_dim`. The GPU attention **kernel is unchanged** — it already strides internally by `num_heads*head_dim`.
- **QK-norm** — per-head RMSNorm over `head_dim` applied to Q and K before RoPE, via `q_norm`/`k_norm` weights. Host-side (both CPU and GPU paths RoPE on host), no-op when weights are nil.
- **Loader** — parse explicit `head_dim`; read `self_attn.q_norm/k_norm` when present; dispatch `model_type: qwen3`; thread `head_dim` through `add_layer` → `LlamaBlock`.

## Validated
- **Qwen3-0.6B** (Q-proj [1024,2048] non-square, QK-norm, thinking mode) generates coherent reasoning on GPU Q8 **and** fp32 (*"...Paris is often referred to as France's capital... The official name is Paris..."*).
- **LLaMA 3.2 1B byte-identical** (default path unchanged).
- 172 specs pass; both builds compile.

## Scope
Dense-attention half only. The `qwen3_moe` MoE wiring (use `MoEFF` as the block FFN + load 128 experts) is the next and final brick, validated on Qwen3-Coder-30B-A3B.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>