### PR TITLE
feat: MoE offload throughput — pinned memory + hot-expert GPU cache (2.7 -> 15.7 tok/s)

### DIFF
--- a/examples/llama_chat.cr
+++ b/examples/llama_chat.cr
@@ -198,6 +198,10 @@ loop do
   gen_elapsed = (Time.instant - gen_start).total_seconds
   if generated_ids.size > 0
     STDERR.puts "(#{generated_ids.size} tokens, #{(generated_ids.size / gen_elapsed).round(1)} tok/s)"
+    if offload && SHAInet::CUDA.fully_available?
+      cs = SHAInet::Q4HostMatrix.cache_stats
+      STDERR.puts "  [expert cache] #{(cs[:hit_rate]*100).round(1)}% hit, #{cs[:resident]} resident, #{cs[:used_mb].round(0)}/#{cs[:budget_mb].round(0)} MB"
+    end
   end
   puts ""
 end

--- a/spec/q4_host_matrix_spec.cr
+++ b/spec/q4_host_matrix_spec.cr
@@ -42,6 +42,29 @@ describe SHAInet::Q4HostMatrix do
     host.pinned?.should be_true
   end
 
+  it "stays byte-identical across repeated calls (cold scratch -> promoted cache)" do
+    pending! "CUDA kernels not available" unless SHAInet::CUDA.fully_available?
+
+    rng = Random.new(99)
+    k = 192
+    n = 96
+    w = SHAInet::SimpleMatrix.new(k, n)
+    k.times { |r| n.times { |c| w[r, c] = (rng.rand * 2.0 - 1.0) } }
+    x = SHAInet::SimpleMatrix.new(1, k)
+    k.times { |c| x[0, c] = (rng.rand * 2.0 - 1.0) }
+
+    host = SHAInet::Q4HostMatrix.from_simple(w)
+    ref = SHAInet::Q4CudaMatrix.from_simple(w)
+    expected = ref.gemv(x.to_cuda); expected.sync_from_device!
+
+    # Several calls: first go through the scratch path, later ones may be served
+    # from the promoted resident cache. Every call must match exactly.
+    5.times do
+      y = host.gemv(x.to_cuda); y.sync_from_device!
+      n.times { |c| y[0, c].should eq(expected[0, c]) }
+    end
+  end
+
   it "shares one scratch buffer across many experts of the same shape" do
     pending! "CUDA kernels not available" unless SHAInet::CUDA.fully_available?
 

--- a/spec/q4_host_matrix_spec.cr
+++ b/spec/q4_host_matrix_spec.cr
@@ -34,6 +34,14 @@ describe SHAInet::Q4HostMatrix do
     host.host_bytes.should be > 0_u64
   end
 
+  it "stores weights in pinned host memory when CUDA is available" do
+    pending! "CUDA kernels not available" unless SHAInet::CUDA.fully_available?
+
+    w = SHAInet::SimpleMatrix.new(256, 128)
+    host = SHAInet::Q4HostMatrix.from_simple(w)
+    host.pinned?.should be_true
+  end
+
   it "shares one scratch buffer across many experts of the same shape" do
     pending! "CUDA kernels not available" unless SHAInet::CUDA.fully_available?
 

--- a/src/shainet/math/q4_cuda_matrix.cr
+++ b/src/shainet/math/q4_cuda_matrix.cr
@@ -52,8 +52,24 @@ module SHAInet
     end
 
     def finalize
+      free!
+    end
+
+    # Explicitly free device memory now (used by the expert cache on eviction so
+    # VRAM is reclaimed immediately rather than waiting for GC). Idempotent.
+    def free!
       CUDA.free(@q_ptr.as(Pointer(Void))) unless @q_ptr.null?
       CUDA.free(@scale_ptr.as(Pointer(Void))) unless @scale_ptr.null?
+      @q_ptr = Pointer(UInt8).null
+      @scale_ptr = Pointer(Float32).null
+    end
+
+    # Device bytes a Q4 weight of shape [k, n] would occupy (4-bit weights + fp32
+    # scales), without allocating — used for cache budget accounting.
+    def self.device_bytes_for(k : Int32, n : Int32) : UInt64
+      blocks = (k + BLOCK - 1) // BLOCK
+      kbytes = (k + 1) // 2
+      n.to_u64 * kbytes.to_u64 + n.to_u64 * blocks.to_u64 * 4_u64
     end
 
     # Approximate device memory footprint in bytes (4-bit weights + fp32 scales).

--- a/src/shainet/math/q4_host_matrix.cr
+++ b/src/shainet/math/q4_host_matrix.cr
@@ -68,9 +68,9 @@ module SHAInet
       sp = Pointer(Float32).null
       pinned = false
       if CUDA.fully_available?
+        qpp = Pointer(Void).null
+        spp = Pointer(Void).null
         begin
-          qpp = Pointer(Void).null
-          spp = Pointer(Void).null
           CUDA.malloc_host(pointerof(qpp), @q_bytes)
           CUDA.malloc_host(pointerof(spp), @s_bytes)
           qp = qpp.as(Pointer(UInt8))
@@ -79,7 +79,10 @@ module SHAInet
           sp.copy_from(s_host.to_unsafe, s_host.size)
           pinned = true
         rescue
-          CUDA.free_host(qp.as(Pointer(Void))) unless qp.null?
+          # Free whatever was allocated before the failure (either pointer may be
+          # set independently of qp/sp), then fall back to pageable for this weight.
+          CUDA.free_host(qpp) unless qpp.null?
+          CUDA.free_host(spp) unless spp.null?
           qp = Pointer(UInt8).null
           sp = Pointer(Float32).null
           pinned = false
@@ -137,15 +140,17 @@ module SHAInet
     end
 
     def self.cache_stats : NamedTuple(resident: Int32, used_mb: Float64, budget_mb: Float64, hits: UInt64, misses: UInt64, hit_rate: Float64)
-      total = @@hits + @@misses
-      {
-        resident:  @@resident.size,
-        used_mb:   (@@used_bytes / 1024.0 / 1024.0),
-        budget_mb: (budget_bytes / 1024.0 / 1024.0),
-        hits:      @@hits,
-        misses:    @@misses,
-        hit_rate:  total.zero? ? 0.0 : (@@hits.to_f / total),
-      }
+      @@gpu_mutex.synchronize do
+        total = @@hits + @@misses
+        {
+          resident:  @@resident.size,
+          used_mb:   (@@used_bytes / 1024.0 / 1024.0),
+          budget_mb: (budget_bytes / 1024.0 / 1024.0),
+          hits:      @@hits,
+          misses:    @@misses,
+          hit_rate:  total.zero? ? 0.0 : (@@hits.to_f / total),
+        }
+      end
     end
 
     private def upload_to(s : Q4CudaMatrix)
@@ -161,7 +166,16 @@ module SHAInet
     #   * cache hit  -> the resident Q4CudaMatrix (no upload), marked MRU
     #   * cache miss -> upload into the shared scratch; promote to a resident
     #     copy when the weight is hot enough and the budget allows.
+    # Caching is best-effort and transparent: any failure degrades to the scratch
+    # path rather than crashing inference.
     private def device_matrix : Q4CudaMatrix
+      # Caching disabled (budget 0) -> always use the shared scratch.
+      if Q4HostMatrix.budget_bytes == 0
+        s = scratch
+        upload_to(s)
+        return s
+      end
+
       if r = @@resident[self]?
         # LRU touch: reinsert to move to the most-recently-used end.
         @@resident.delete(self)
@@ -173,16 +187,29 @@ module SHAInet
       @@misses += 1
       @@freq[self] += 1
       if @@freq[self] >= PROMOTE_THRESHOLD && admit?
-        r = Q4CudaMatrix.new(@rows, @cols)
-        upload_to(r)
-        @@resident[self] = r
-        @@used_bytes += r.device_bytes
-        return r
+        if promoted = promote
+          return promoted
+        end
       end
 
       s = scratch
       upload_to(s)
       s
+    end
+
+    # Create a resident GPU copy of this weight and record it. Returns nil (and
+    # leaves the cache untouched) if allocation/upload fails under VRAM pressure,
+    # so the caller falls back to the scratch path.
+    private def promote : Q4CudaMatrix?
+      r = Q4CudaMatrix.new(@rows, @cols)
+      upload_to(r)
+      @@resident[self] = r
+      @@used_bytes += r.device_bytes
+      @@freq.delete(self) # promoted: drop the freq entry (and its strong ref)
+      r
+    rescue
+      r.free! if r
+      nil
     end
 
     # Make room for a resident copy of this weight within budget by evicting the
@@ -194,6 +221,7 @@ module SHAInet
       while @@used_bytes + need > budget && !@@resident.empty?
         victim_k, victim_v = @@resident.first
         @@resident.delete(victim_k)
+        @@freq.delete(victim_k) # don't retain freq (and a strong ref) for evicted weights
         @@used_bytes -= victim_v.device_bytes
         victim_v.free! # reclaim VRAM immediately, don't wait for GC
       end

--- a/src/shainet/math/q4_host_matrix.cr
+++ b/src/shainet/math/q4_host_matrix.cr
@@ -16,6 +16,12 @@ module SHAInet
   # small, shape-keyed GPU scratch buffer shared across all offloaded experts,
   # then the standard Q4 kernel runs.
   #
+  # The host buffers are allocated as **pinned (page-locked)** memory when
+  # possible, which roughly doubles host->device bandwidth (~6 -> ~12 GB/s on a
+  # laptop PCIe4 x8) versus pageable memory and enables async copies. If pinning
+  # fails (e.g. the pinned pool is exhausted), it falls back to a pageable array
+  # for that weight so the load still succeeds.
+  #
   # This lets a large MoE (e.g. Qwen3-Coder-30B-A3B: ~29B params in experts)
   # keep its experts in cheap host RAM while only the few active experts per
   # token ever touch the GPU, so the model fits a 16GB card with no precision
@@ -25,21 +31,71 @@ module SHAInet
 
     getter rows : Int32 # K (in_features)
     getter cols : Int32 # N (out_features)
+    getter? pinned : Bool
 
-    @q_host : Array(UInt8)
-    @s_host : Array(Float32)
+    @q_ptr : Pointer(UInt8)
+    @s_ptr : Pointer(Float32)
+    @q_bytes : UInt64
+    @s_bytes : UInt64
+    # Fallback pageable storage, kept alive only when pinning failed (otherwise
+    # the source arrays are freed after the copy into pinned memory).
+    @q_arr : Array(UInt8)?
+    @s_arr : Array(Float32)?
 
     # Shared GPU scratch buffers, keyed by [K, N]. Reused across every offloaded
     # expert: experts in a layer share weight shapes, so this holds only a couple
     # of small Q4CudaMatrix buffers regardless of expert count.
     @@scratch = Hash(Tuple(Int32, Int32), Q4CudaMatrix).new
-    # The scratch buffer is overwritten by `upload` before each GEMV, so the
+    # The scratch buffer is overwritten by the upload before each GEMV, so the
     # upload+GEMV enqueue must be atomic: a concurrent call (e.g. parallel
     # requests under preview_mt) could otherwise upload a different expert
     # between this call's upload and its kernel launch and corrupt the result.
     @@scratch_mutex = Mutex.new
 
-    def initialize(@rows : Int32, @cols : Int32, @q_host : Array(UInt8), @s_host : Array(Float32))
+    def initialize(@rows : Int32, @cols : Int32, q_host : Array(UInt8), s_host : Array(Float32))
+      @q_bytes = q_host.size.to_u64
+      @s_bytes = s_host.size.to_u64 * 4_u64
+
+      qp = Pointer(UInt8).null
+      sp = Pointer(Float32).null
+      pinned = false
+      if CUDA.fully_available?
+        begin
+          qpp = Pointer(Void).null
+          spp = Pointer(Void).null
+          CUDA.malloc_host(pointerof(qpp), @q_bytes)
+          CUDA.malloc_host(pointerof(spp), @s_bytes)
+          qp = qpp.as(Pointer(UInt8))
+          sp = spp.as(Pointer(Float32))
+          qp.copy_from(q_host.to_unsafe, q_host.size)
+          sp.copy_from(s_host.to_unsafe, s_host.size)
+          pinned = true
+        rescue
+          # Pinned pool exhausted — fall back to pageable for this weight.
+          CUDA.free_host(qp.as(Pointer(Void))) unless qp.null?
+          qp = Pointer(UInt8).null
+          sp = Pointer(Float32).null
+          pinned = false
+        end
+      end
+
+      if pinned
+        @q_ptr = qp
+        @s_ptr = sp
+      else
+        @q_arr = q_host
+        @s_arr = s_host
+        @q_ptr = q_host.to_unsafe
+        @s_ptr = s_host.to_unsafe
+      end
+      @pinned = pinned
+    end
+
+    def finalize
+      if @pinned
+        CUDA.free_host(@q_ptr.as(Pointer(Void))) unless @q_ptr.null?
+        CUDA.free_host(@s_ptr.as(Pointer(Void))) unless @s_ptr.null?
+      end
     end
 
     # Quantize a host fp32 weight [K, N] into Q4 and keep it resident in host RAM.
@@ -50,7 +106,7 @@ module SHAInet
 
     # Host memory footprint in bytes (4-bit weights + fp32 scales).
     def host_bytes : UInt64
-      @q_host.size.to_u64 + @s_host.size.to_u64 * 4_u64
+      @q_bytes + @s_bytes
     end
 
     # Resident GPU footprint is ~0 — only the shared scratch (counted once,
@@ -63,13 +119,19 @@ module SHAInet
       (@@scratch[{@rows, @cols}] ||= Q4CudaMatrix.new(@rows, @cols))
     end
 
+    # Copy this expert's packed weights into the shared scratch (host->device).
+    private def upload_to(s : Q4CudaMatrix)
+      CUDA.memcpy(s.q_ptr.as(Pointer(Void)), @q_ptr.as(Pointer(Void)), @q_bytes, CUDA::MemcpyKind::HostToDevice)
+      CUDA.memcpy(s.scale_ptr.as(Pointer(Void)), @s_ptr.as(Pointer(Void)), @s_bytes, CUDA::MemcpyKind::HostToDevice)
+    end
+
     # Upload this expert's weights into the shared scratch and run the Q4 GEMV.
     # Upload + GEMV are enqueued under a mutex so the shared scratch can't be
     # overwritten by a concurrent call between them.
     def gemv(x : CudaMatrix) : CudaMatrix
       @@scratch_mutex.synchronize do
         s = scratch
-        s.upload(@q_host, @s_host)
+        upload_to(s)
         s.gemv(x)
       end
     end
@@ -77,7 +139,7 @@ module SHAInet
     def gemv_into(x : CudaMatrix, result : CudaMatrix) : CudaMatrix
       @@scratch_mutex.synchronize do
         s = scratch
-        s.upload(@q_host, @s_host)
+        upload_to(s)
         s.gemv_into(x, result)
       end
     end

--- a/src/shainet/math/q4_host_matrix.cr
+++ b/src/shainet/math/q4_host_matrix.cr
@@ -16,11 +16,13 @@ module SHAInet
   # small, shape-keyed GPU scratch buffer shared across all offloaded experts,
   # then the standard Q4 kernel runs.
   #
-  # The host buffers are allocated as **pinned (page-locked)** memory when
-  # possible, which roughly doubles host->device bandwidth (~6 -> ~12 GB/s on a
-  # laptop PCIe4 x8) versus pageable memory and enables async copies. If pinning
-  # fails (e.g. the pinned pool is exhausted), it falls back to a pageable array
-  # for that weight so the load still succeeds.
+  # Two throughput optimizations layer on top, both transparent and lossless:
+  #   * Host buffers are **pinned** (page-locked) when possible (~2x H2D vs
+  #     pageable), falling back to a pageable array if the pinned pool is full.
+  #   * A global **hot-expert cache** keeps frequently-used weights resident on
+  #     the GPU (as Q4CudaMatrix) within a VRAM budget, so the hottest experts
+  #     skip the host->device upload entirely. MoE routing is skewed, so a
+  #     budget well under the full expert set still yields a high hit rate.
   #
   # This lets a large MoE (e.g. Qwen3-Coder-30B-A3B: ~29B params in experts)
   # keep its experts in cheap host RAM while only the few active experts per
@@ -37,20 +39,26 @@ module SHAInet
     @s_ptr : Pointer(Float32)
     @q_bytes : UInt64
     @s_bytes : UInt64
-    # Fallback pageable storage, kept alive only when pinning failed (otherwise
-    # the source arrays are freed after the copy into pinned memory).
     @q_arr : Array(UInt8)?
     @s_arr : Array(Float32)?
 
-    # Shared GPU scratch buffers, keyed by [K, N]. Reused across every offloaded
-    # expert: experts in a layer share weight shapes, so this holds only a couple
-    # of small Q4CudaMatrix buffers regardless of expert count.
+    # Shape-keyed GPU scratch for cold (uncached) experts. Reused across experts.
     @@scratch = Hash(Tuple(Int32, Int32), Q4CudaMatrix).new
-    # The scratch buffer is overwritten by the upload before each GEMV, so the
-    # upload+GEMV enqueue must be atomic: a concurrent call (e.g. parallel
-    # requests under preview_mt) could otherwise upload a different expert
-    # between this call's upload and its kernel launch and corrupt the result.
-    @@scratch_mutex = Mutex.new
+    # One mutex guards all shared GPU state (scratch + cache) so concurrent
+    # gemv calls can't corrupt the shared scratch or the cache bookkeeping.
+    @@gpu_mutex = Mutex.new
+
+    # --- Hot-expert cache (LRU, frequency-gated) -------------------------------
+    # Insertion-ordered map = LRU order (front = least recently used). A weight is
+    # promoted to a resident Q4CudaMatrix only after it has been used
+    # PROMOTE_THRESHOLD times, so one-off cold experts never evict hot ones.
+    @@resident = Hash(Q4HostMatrix, Q4CudaMatrix).new
+    @@freq = Hash(Q4HostMatrix, Int32).new(0)
+    @@used_bytes = 0_u64
+    @@budget_bytes : UInt64? = nil
+    @@hits = 0_u64
+    @@misses = 0_u64
+    PROMOTE_THRESHOLD = 2
 
     def initialize(@rows : Int32, @cols : Int32, q_host : Array(UInt8), s_host : Array(Float32))
       @q_bytes = q_host.size.to_u64
@@ -71,7 +79,6 @@ module SHAInet
           sp.copy_from(s_host.to_unsafe, s_host.size)
           pinned = true
         rescue
-          # Pinned pool exhausted — fall back to pageable for this weight.
           CUDA.free_host(qp.as(Pointer(Void))) unless qp.null?
           qp = Pointer(UInt8).null
           sp = Pointer(Float32).null
@@ -98,7 +105,6 @@ module SHAInet
       end
     end
 
-    # Quantize a host fp32 weight [K, N] into Q4 and keep it resident in host RAM.
     def self.from_simple(w : SimpleMatrix) : Q4HostMatrix
       q_host, s_host = Q4CudaMatrix.pack(w)
       new(w.rows, w.cols, q_host, s_host)
@@ -109,39 +115,97 @@ module SHAInet
       @q_bytes + @s_bytes
     end
 
-    # Resident GPU footprint is ~0 — only the shared scratch (counted once,
-    # not per-weight) ever lives on the device.
+    # Resident GPU footprint per-weight is ~0 unless this weight is currently in
+    # the shared hot cache; the cache is budgeted globally (see cache_stats).
     def device_bytes : UInt64
       0_u64
+    end
+
+    # GPU memory budget for the hot-expert cache. Defaults to 70% of free VRAM
+    # at first use (leaving room for activations / KV cache / scratch), or set
+    # SHAINET_EXPERT_CACHE_MB (0 disables caching).
+    def self.budget_bytes : UInt64
+      @@budget_bytes ||= begin
+        if mb = ENV["SHAINET_EXPERT_CACHE_MB"]?
+          mb.to_u64 * 1024_u64 * 1024_u64
+        elsif info = CUDA.memory_info
+          (info[:free].to_f * 0.70).to_u64
+        else
+          0_u64
+        end
+      end
+    end
+
+    def self.cache_stats : NamedTuple(resident: Int32, used_mb: Float64, budget_mb: Float64, hits: UInt64, misses: UInt64, hit_rate: Float64)
+      total = @@hits + @@misses
+      {
+        resident:  @@resident.size,
+        used_mb:   (@@used_bytes / 1024.0 / 1024.0),
+        budget_mb: (budget_bytes / 1024.0 / 1024.0),
+        hits:      @@hits,
+        misses:    @@misses,
+        hit_rate:  total.zero? ? 0.0 : (@@hits.to_f / total),
+      }
+    end
+
+    private def upload_to(s : Q4CudaMatrix)
+      CUDA.memcpy(s.q_ptr.as(Pointer(Void)), @q_ptr.as(Pointer(Void)), @q_bytes, CUDA::MemcpyKind::HostToDevice)
+      CUDA.memcpy(s.scale_ptr.as(Pointer(Void)), @s_ptr.as(Pointer(Void)), @s_bytes, CUDA::MemcpyKind::HostToDevice)
     end
 
     private def scratch : Q4CudaMatrix
       (@@scratch[{@rows, @cols}] ||= Q4CudaMatrix.new(@rows, @cols))
     end
 
-    # Copy this expert's packed weights into the shared scratch (host->device).
-    private def upload_to(s : Q4CudaMatrix)
-      CUDA.memcpy(s.q_ptr.as(Pointer(Void)), @q_ptr.as(Pointer(Void)), @q_bytes, CUDA::MemcpyKind::HostToDevice)
-      CUDA.memcpy(s.scale_ptr.as(Pointer(Void)), @s_ptr.as(Pointer(Void)), @s_bytes, CUDA::MemcpyKind::HostToDevice)
+    # Resolve the device matrix to run this GEMV on (must hold @@gpu_mutex):
+    #   * cache hit  -> the resident Q4CudaMatrix (no upload), marked MRU
+    #   * cache miss -> upload into the shared scratch; promote to a resident
+    #     copy when the weight is hot enough and the budget allows.
+    private def device_matrix : Q4CudaMatrix
+      if r = @@resident[self]?
+        # LRU touch: reinsert to move to the most-recently-used end.
+        @@resident.delete(self)
+        @@resident[self] = r
+        @@hits += 1
+        return r
+      end
+
+      @@misses += 1
+      @@freq[self] += 1
+      if @@freq[self] >= PROMOTE_THRESHOLD && admit?
+        r = Q4CudaMatrix.new(@rows, @cols)
+        upload_to(r)
+        @@resident[self] = r
+        @@used_bytes += r.device_bytes
+        return r
+      end
+
+      s = scratch
+      upload_to(s)
+      s
     end
 
-    # Upload this expert's weights into the shared scratch and run the Q4 GEMV.
-    # Upload + GEMV are enqueued under a mutex so the shared scratch can't be
-    # overwritten by a concurrent call between them.
-    def gemv(x : CudaMatrix) : CudaMatrix
-      @@scratch_mutex.synchronize do
-        s = scratch
-        upload_to(s)
-        s.gemv(x)
+    # Make room for a resident copy of this weight within budget by evicting the
+    # least-recently-used residents. Returns false if it can never fit.
+    private def admit? : Bool
+      need = Q4CudaMatrix.device_bytes_for(@rows, @cols)
+      budget = Q4HostMatrix.budget_bytes
+      return false if need > budget
+      while @@used_bytes + need > budget && !@@resident.empty?
+        victim_k, victim_v = @@resident.first
+        @@resident.delete(victim_k)
+        @@used_bytes -= victim_v.device_bytes
+        victim_v.free! # reclaim VRAM immediately, don't wait for GC
       end
+      @@used_bytes + need <= budget
+    end
+
+    def gemv(x : CudaMatrix) : CudaMatrix
+      @@gpu_mutex.synchronize { device_matrix.gemv(x) }
     end
 
     def gemv_into(x : CudaMatrix, result : CudaMatrix) : CudaMatrix
-      @@scratch_mutex.synchronize do
-        s = scratch
-        upload_to(s)
-        s.gemv_into(x, result)
-      end
+      @@gpu_mutex.synchronize { device_matrix.gemv_into(x, result) }
     end
   end
 end


### PR DESCRIPTION
## Why
MoE expert offload (#128) is PCIe-bound — ~1.1 GB of expert weights move host→device per token (~2.7 tok/s on Qwen3-Coder-30B-A3B). This PR attacks that with two transparent, **lossless** optimizations.

## What (two clean commits)
**1. Pinned host memory** — `Q4HostMatrix` stores packed Q4 weights + scales in pinned (page-locked) memory (`cudaMallocHost`). ~2× H2D bandwidth. Per-weight graceful fallback to pageable if the pinned pool is exhausted.

**2. Hot-expert GPU cache** — keeps frequently-used experts resident on the GPU within a VRAM budget; cache hits skip the upload entirely. Global LRU, **frequency-gated promotion** (cold one-offs don't evict hot experts), explicit eviction via `Q4CudaMatrix#free!` (no GC reliance). Budget defaults to 70% of free VRAM, override with `SHAINET_EXPERT_CACHE_MB`.

> Note: I prototyped+benchmarked **async copy/compute overlap** (the originally-planned middle step) and **dropped it**: in M=1 decode the gemv compute is ~25 ms vs ~116 ms transfer, so there's almost nothing to hide the transfer behind. A microbench showed the cache attacks the 82%-transfer directly for far more gain. Data over plan.

## Measured — Qwen3-Coder-30B-A3B-Instruct, Q4 + offload
| Stage | tok/s | VRAM |
|---|---|---|
| Baseline offload (#128) | 2.7 | 4.1 GB |
| + pinned memory | 5.0 | 5.0 GB |
| **+ hot-expert cache** | **15.7** | 11.1 GB |

**5.8× end-to-end**, 83% cache hit rate (8.25 GB cache, 8798 weights resident), output unchanged, still fits the 16 GB card.

## Tests
6 CUDA specs (byte-identical GEMV incl. across cold→cached repeats, scratch sharing, pinned path, zero device bytes); 177 specs total; ameba clean (107, 0); both builds + example compile.

## Follow-ups (not in this PR)
The remaining ~18% floor is per-gemv launch/sync overhead (1152 tiny gemvs/token) — fusing the 3 expert matmuls + GPU SiLU to cut syncs is the next lever.