### PR TITLE
perf: cut GPU prefill memory — shared attention scratch + explicit temporary frees

### DIFF
--- a/src/shainet/cuda.cr
+++ b/src/shainet/cuda.cr
@@ -124,6 +124,15 @@ module SHAInet
     def malloc(ptr : Pointer(Pointer(Void)), size : LibC::SizeT)
       rslt = LibCUDARuntime.cudaMalloc(ptr, size)
       unless rslt.zero?
+        # Likely out of memory. Dead GPU matrices may not be reclaimed yet: their
+        # Crystal wrappers are tiny, so GC rarely runs during GPU-heavy loops (a
+        # prefill can create hundreds of large device buffers without enough host
+        # pressure to trigger a collection). Force GC to run their finalizers
+        # (which cudaFree), then retry before giving up.
+        GC.collect
+        rslt = LibCUDARuntime.cudaMalloc(ptr, size)
+      end
+      unless rslt.zero?
         Log.error { "CUDA.malloc: cudaMalloc failed with result #{rslt} for size #{size}" }
         raise "CUDA memory allocation failed"
       end

--- a/src/shainet/math/cuda_matrix.cr
+++ b/src/shainet/math/cuda_matrix.cr
@@ -214,19 +214,24 @@ module SHAInet
     end
 
     def finalize
-      # Each CudaMatrix cleans up its own GPU memory directly
-      if dptr = @device_ptr
-        unless dptr.null?
-          begin
-            CUDA.free(dptr.as(Pointer(Void)))
-            @@total_gpu_memory_allocated -= @gpu_memory_size
-            @@active_matrices -= 1
-            @device_ptr = Pointer(Float32).null
-            @gpu_memory_size = 0_u64
-          rescue ex
-            Log.warn { "CudaMatrix.finalize: Failed to free GPU memory for #{@rows}x#{@cols}: #{ex}" }
-          end
+      free!
+    end
+
+    # Explicitly release this matrix's GPU memory now. Idempotent. Only call on
+    # matrices that are no longer referenced (e.g. local temporaries in a hot
+    # loop) — conservative GC can't reclaim them mid-forward, so without this the
+    # device buffers pile up across layers until OOM.
+    def free!
+      if (dptr = @device_ptr) && !dptr.null?
+        begin
+          CUDA.free(dptr.as(Pointer(Void)))
+          @@total_gpu_memory_allocated -= @gpu_memory_size
+          @@active_matrices -= 1
+        rescue ex
+          Log.warn { "CudaMatrix.free!: failed to free GPU memory for #{@rows}x#{@cols}: #{ex}" }
         end
+        @device_ptr = Pointer(Float32).null
+        @gpu_memory_size = 0_u64
       end
     end
 

--- a/src/shainet/transformer/llama_block.cr
+++ b/src/shainet/transformer/llama_block.cr
@@ -54,15 +54,18 @@ module SHAInet
     @gpu_k_cache : Pointer(Float32) = Pointer(Float32).null
     @gpu_v_cache : Pointer(Float32) = Pointer(Float32).null
     @gpu_cache_cap : Int32 = 0
-    # Persistent device buffers for the attention hot path (grow-only, never
-    # freed mid-inference so they cannot be GC-collected during a kernel).
-    @gpu_staging : Pointer(Float32) = Pointer(Float32).null
-    @gpu_staging_cap : Int32 = 0
-    @gpu_attn_out : Pointer(Float32) = Pointer(Float32).null
-    @gpu_attn_out_cap : Int32 = 0
-    @gpu_attn_ws : Pointer(Float32) = Pointer(Float32).null
-    @gpu_attn_ws_cap : Int32 = 0
-    @staging_host : Array(Float32) = Array(Float32).new
+    # Persistent device scratch for the attention hot path. SHARED across all
+    # blocks (class-level): blocks run sequentially, so one grow-only scratch set
+    # serves every layer instead of each of N layers holding its own ~(heads×
+    # seq×seq) workspace (which was ~N× redundant and exhausted VRAM on long
+    # prefills). The KV cache above stays per-instance.
+    @@gpu_staging : Pointer(Float32) = Pointer(Float32).null
+    @@gpu_staging_cap : Int32 = 0
+    @@gpu_attn_out : Pointer(Float32) = Pointer(Float32).null
+    @@gpu_attn_out_cap : Int32 = 0
+    @@gpu_attn_ws : Pointer(Float32) = Pointer(Float32).null
+    @@gpu_attn_ws_cap : Int32 = 0
+    @@staging_host : Array(Float32) = Array(Float32).new
     @gpu_attn_avail : Bool? = nil
     # Force the CPU attention path even when CUDA is available (tests/fallback).
     property? force_cpu_attention : Bool = false
@@ -119,7 +122,9 @@ module SHAInet
     end
 
     def finalize
-      {@gpu_k_cache, @gpu_v_cache, @gpu_staging, @gpu_attn_out, @gpu_attn_ws}.each do |p|
+      # Only free the per-instance KV cache; the attention scratch is class-level
+      # and shared across all blocks, so it must not be freed per instance.
+      {@gpu_k_cache, @gpu_v_cache}.each do |p|
         CUDA.free(p.as(Pointer(Void))) unless p.null?
       end
     end
@@ -413,14 +418,14 @@ module SHAInet
       ws_floats = @num_heads * new_tokens * total_len
 
       ensure_gpu_cache!(total_len)
-      @gpu_staging, @gpu_staging_cap = grow_dev_buf(@gpu_staging, @gpu_staging_cap, staging_floats)
-      @gpu_attn_out, @gpu_attn_out_cap = grow_dev_buf(@gpu_attn_out, @gpu_attn_out_cap, q_floats)
-      @gpu_attn_ws, @gpu_attn_ws_cap = grow_dev_buf(@gpu_attn_ws, @gpu_attn_ws_cap, ws_floats)
+      @@gpu_staging, @@gpu_staging_cap = grow_dev_buf(@@gpu_staging, @@gpu_staging_cap, staging_floats)
+      @@gpu_attn_out, @@gpu_attn_out_cap = grow_dev_buf(@@gpu_attn_out, @@gpu_attn_out_cap, q_floats)
+      @@gpu_attn_ws, @@gpu_attn_ws_cap = grow_dev_buf(@@gpu_attn_ws, @@gpu_attn_ws_cap, ws_floats)
 
-      st = @staging_host
+      st = @@staging_host
       if st.size < staging_floats
         st = Array(Float32).new(staging_floats, 0.0_f32)
-        @staging_host = st
+        @@staging_host = st
       end
       stp = st.to_unsafe
 
@@ -461,15 +466,15 @@ module SHAInet
         end
       end
 
-      CUDA.memcpy(@gpu_staging.as(Pointer(Void)), stp.as(Pointer(Void)),
+      CUDA.memcpy(@@gpu_staging.as(Pointer(Void)), stp.as(Pointer(Void)),
         staging_floats.to_u64 * 4_u64, CUDA::MemcpyKind::HostToDevice)
-      CUDA.kv_cache_append_f32(@gpu_staging, @gpu_k_cache, @gpu_v_cache,
+      CUDA.kv_cache_append_f32(@@gpu_staging, @gpu_k_cache, @gpu_v_cache,
         new_tokens, start_pos, @num_kv_heads, head_dim, @gpu_cache_cap)
-      CUDA.attention_kv_f32(@gpu_staging + 2 * kv_floats, @gpu_k_cache, @gpu_v_cache,
-        @gpu_attn_out, @gpu_attn_ws, new_tokens, start_pos,
+      CUDA.attention_kv_f32(@@gpu_staging + 2 * kv_floats, @gpu_k_cache, @gpu_v_cache,
+        @@gpu_attn_out, @@gpu_attn_ws, new_tokens, start_pos,
         @num_heads, heads_per_kv, head_dim, @gpu_cache_cap, scale)
       # Synchronous D2H read-back also orders after both kernels above.
-      CUDA.memcpy(output.data.to_unsafe.as(Pointer(Void)), @gpu_attn_out.as(Pointer(Void)),
+      CUDA.memcpy(output.data.to_unsafe.as(Pointer(Void)), @@gpu_attn_out.as(Pointer(Void)),
         q_floats.to_u64 * 4_u64, CUDA::MemcpyKind::DeviceToHost)
     end
 
@@ -741,6 +746,8 @@ module SHAInet
           result_gpu.sync_from_device!("q8_gemm_out") if result_gpu.device_dirty?
           result = SimpleMatrix.new(result_gpu.rows, result_gpu.cols)
           result.data.to_unsafe.copy_from(result_gpu.raw_data.to_unsafe, result_gpu.rows * result_gpu.cols)
+          x_gpu.free!
+          result_gpu.free!
           result
         end
       elsif w.is_a?(CudaMatrix)
@@ -752,6 +759,8 @@ module SHAInet
         result_gpu.sync_from_device!("gemm_out") if result_gpu.device_dirty?
         result = SimpleMatrix.new(result_gpu.rows, result_gpu.cols)
         result_gpu.rows.times { |r| result_gpu.cols.times { |c| result[r, c] = result_gpu[r, c].to_f32 } }
+        x_gpu.free!
+        result_gpu.free!
         result
       else
         x * w

--- a/src/shainet/transformer/moe_ff.cr
+++ b/src/shainet/transformer/moe_ff.cr
@@ -47,7 +47,11 @@ module SHAInet
       r = @router
       if r.is_a?(CudaMatrix)
         xg = x.to_cuda
-        (xg * r).to_simple
+        prod = xg * r
+        res = prod.to_simple
+        xg.free!
+        prod.free!
+        res
       else
         x * r.as(SimpleMatrix)
       end


### PR DESCRIPTION
## Problem
A multi-layer prefill grew VRAM **~90 MB per layer** (~4.3 GB over 48 layers on Qwen3-Coder-30B), OOM-ing large MoE models — even though the math fits.

## Root cause
1. **Per-block attention scratch was N× redundant.** Each `LlamaBlock` kept its *own* grow-only GPU attention scratch (the `heads×seq×seq` scores workspace + K/V staging + output), retained for the instance's lifetime. With 48 layers that's 48 copies of a ~60–90 MB buffer all resident at once.
2. **Prefill device temporaries weren't reclaimed.** `gpu_matmul` (M>1 path) and the MoE router allocate device `CudaMatrix` temporaries that conservative GC can't free mid-forward (live pointers on the deep call stack), so they accumulated.

## Fix
1. **Share the attention scratch across blocks** (class-level). Blocks execute sequentially, so one grow-only scratch set serves every layer; it grows once to the max size instead of N× redundancy. The **KV cache stays per-instance** (it must).
2. **Explicit `CudaMatrix#free!`** on the local temporaries in `gpu_matmul` and the MoE router right after they're consumed.
3. **GC-collect-and-retry on `cudaMalloc` OOM** as a safety net — reclaims dead device matrices before failing.

## Measured (Qwen3-Coder-30B-A3B, Q4 + offload)
- Prefill VRAM growth: **+4.3 GB → +0.3 GB**.
- The expert cache + a real agent prefill now **coexist on a 16 GB GPU** (was OOM at 100%; now ~78%).

## Correctness
- Attention / Q4 / Q4Host / MoE specs pass (14 examples); `llama_attention_gpu_spec` numerically validates attention through the shared scratch.
- Qwen3-0.6B generation coherent/unchanged.
- Both builds + ameba clean.

Unblocks the agentic example (#131) running the 30B with the cache on.