### PR TITLE
chore: pin ameba to a fixed commit and run it in CI

### DIFF
--- a/.github/workflows/ameba.yml
+++ b/.github/workflows/ameba.yml
@@ -15,5 +15,16 @@ jobs:
       - name: Download source
         uses: actions/checkout@v6
 
-      - name: Run Ameba Linter
-        uses: crystal-ameba/github-action@master
+      - name: Install Crystal
+        uses: crystal-lang/install-crystal@v1
+
+      - name: Install dependencies
+        run: shards install
+
+      # Build and run the exact ameba commit pinned in shard.yml/shard.lock so
+      # CI lint matches what developers run locally (no version skew).
+      - name: Build pinned Ameba
+        run: crystal build lib/ameba/src/cli.cr -o bin/ameba
+
+      - name: Run Ameba
+        run: ./bin/ameba

--- a/shard.yml
+++ b/shard.yml
@@ -10,6 +10,6 @@ crystal: 1.6.2
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    branch: master
+    commit: cd6a0cf8c89a893c6f26b588db13f499911ad543
 
 license: MIT


### PR DESCRIPTION
## Why
`shard.yml` floated ameba on `branch: master` **and** CI used `crystal-ameba/github-action@master` — two independently-moving versions. They drifted apart, causing local-vs-CI lint disagreements (a rule like `Style/HeredocEscape` would exist on CI but not in the locally-built binary, or vice-versa), which repeatedly cost time on otherwise-green PRs.

## What
- Pin ameba to commit `cd6a0cf` in `shard.yml` (lock already matches).
- CI now `shards install` + builds and runs that **exact pinned** ameba (`crystal build lib/ameba/src/cli.cr -o bin/ameba`) instead of the floating Docker action.

## Result
CI lint == local lint, deterministically. Verified: pinned ameba builds and reports **0 failures** across the project. Bumping ameba is now a deliberate one-line change to the pinned commit.