### PR TITLE
fix(agent): raise per-response token budget so tool calls aren't truncated

### DIFF
--- a/examples/agent.cr
+++ b/examples/agent.cr
@@ -536,7 +536,11 @@ end
 # Entry point
 # ----------------------------------------------------------------------------
 model_dir = ARGV[0]?
-max_tokens = (ARGV[1]? || "512").to_i
+# Per-response generation ceiling. This is a safety bound, not a target — the
+# model stops itself on <|im_end|>. It must be large enough that a tool call
+# writing a whole file isn't truncated before its closing </tool_call> tag
+# (which would make the call unparseable). KV cache grows ~linearly with it.
+max_tokens = (ARGV[1]? || ENV["SHAINET_AGENT_MAX_TOKENS"]? || "4096").to_i
 unless model_dir && Dir.exists?(model_dir)
   STDERR.puts "Usage: agent <model-dir> [max_tokens]"
   STDERR.puts "  (point at an already-downloaded model, e.g. ~/models/Qwen3-Coder-30B-A3B-Instruct)"


### PR DESCRIPTION
## Root cause
The agent appeared to 'stall' after announcing intent and never wrote the file. A raw-token dump on a live 30B session showed the model **does** emit a correct `<tool_call><function=write_file>…` with the whole file inline — but the **512-token per-response cap truncated it before the closing `</tool_call>` tag**. `parse_tool_calls` needs that tag, so it matched nothing → the turn silently ended.

## Fix
One line: the model already self-terminates on `<|im_end|>`, so the per-response cap is just a safety bound — **raise the default 512 → 4096** (env `SHAINET_AGENT_MAX_TOKENS`). KV-cache cost grows ~linearly (~0.2-0.4 MB/token on this 30B), so a few-thousand-token ceiling is comfortable on a 16 GB card.

## Verified
- Builds (stub + CUDA no-codegen), `crystal tool format` clean, `ameba` 0.
- 30B (Q4 + MoE offload) end-to-end: `⚒ write_file(path=…, content=<full script>)` now generates completely and parses — the call fires.