### PR TITLE
fix(gpu): make training actually update weights on the CUDA path

### DIFF
--- a/spec/integration_spec.cr
+++ b/spec/integration_spec.cr
@@ -27,7 +27,7 @@ describe SHAInet::Network do
       data: training_set,
       training_type: :adam,
       cost_function: :mse,
-      epochs: 100,
+      epochs: 600,
       error_threshold: 1e-9,
       mini_batch_size: 4,
       log_each: 20,
@@ -35,10 +35,11 @@ describe SHAInet::Network do
 
     # Test the ANN performance - just verify training completed and basic learning occurred
     accuracy = iris.test(test_set)
-    puts "Final accuracy after 100 epochs: #{accuracy}"
+    puts "Final accuracy after 600 epochs: #{accuracy}"
 
-    # With only 100 epochs, we just want to see that some learning happened
-    # and that training is fast (not hours like before)
+    # 600 epochs of true MSE reaches ~0.9 accuracy in about a second; the
+    # threshold below is deliberately loose, it only guards against a
+    # trainer that does not learn at all.
     accuracy.should be > 0.2 # Very basic expectation - just that it's better than random
 
     puts "✓ Training completed quickly and MSE decreased successfully"

--- a/spec/training_convergence_spec.cr
+++ b/spec/training_convergence_spec.cr
@@ -1,0 +1,93 @@
+require "./spec_helper"
+
+# Regression coverage for the GPU training path, which used to leave weights
+# completely unchanged (flat MSE) because CPU-computed gradients and Adam
+# updates were never uploaded to the device, and because the per-batch input /
+# expected workspaces were handed back to the shared workspace pool while still
+# in use.
+describe "training convergence" do
+  it "drives XOR error down with adam" do
+    data = [
+      [[0.0, 0.0], [0.0]],
+      [[1.0, 0.0], [1.0]],
+      [[0.0, 1.0], [1.0]],
+      [[1.0, 1.0], [0.0]],
+    ]
+
+    net = SHAInet::Network.new
+    net.add_layer(:input, 2)
+    net.add_layer(:hidden, 4, SHAInet.sigmoid)
+    net.add_layer(:output, 1, SHAInet.sigmoid)
+    net.fully_connect
+
+    mse = ->do
+      total = 0.0
+      data.each do |sample|
+        got = net.run(sample[0], stealth: true)
+        total += (got[0] - sample[1][0]) ** 2
+      end
+      total / data.size
+    end
+
+    before = mse.call
+
+    net.train(
+      data: data,
+      training_type: :adam,
+      cost_function: :mse,
+      epochs: 3000,
+      error_threshold: -1.0,
+      mini_batch_size: data.size,
+      log_each: 10_000
+    )
+
+    after = mse.call
+    after.should be < before * 0.5
+  end
+
+  it "updates weights for a multi-label sigmoid output layer" do
+    rng = Random.new(1234)
+    pairs = Array(Array(Array(Float64))).new
+    300.times do
+      input = Array(Float64).new(20) { rng.rand < 0.3 ? 1.0 : 0.0 }
+      target = Array(Float64).new(5, 0.0)
+      target[0] = 1.0 if input[0] == 1.0
+      target[3] = 1.0 if input[1] == 1.0 && input[2] == 1.0
+      pairs << [input, target]
+    end
+
+    net = SHAInet::Network.new
+    net.add_layer(:input, 20, SHAInet.sigmoid)
+    net.add_layer(:hidden, 12, SHAInet.sigmoid)
+    net.add_layer(:output, 5, SHAInet.sigmoid)
+    net.fully_connect
+
+    weights_before = net.output_layers.first.as(SHAInet::MatrixLayer).weights
+    snapshot = Array(Float64).new
+    weights_before.rows.times do |i|
+      weights_before.cols.times { |j| snapshot << weights_before[i, j] }
+    end
+
+    net.train(
+      data: pairs,
+      training_type: :adam,
+      cost_function: :mse,
+      epochs: 20,
+      error_threshold: -1.0,
+      mini_batch_size: 32,
+      log_each: 10_000
+    )
+
+    weights_after = net.output_layers.first.as(SHAInet::MatrixLayer).weights
+    changed = 0
+    idx = 0
+    weights_after.rows.times do |i|
+      weights_after.cols.times do |j|
+        changed += 1 if (weights_after[i, j] - snapshot[idx]).abs > 1e-9
+        idx += 1
+      end
+    end
+
+    changed.should eq(idx)
+  end
+end

--- a/spec/training_convergence_spec.cr
+++ b/spec/training_convergence_spec.cr
@@ -20,7 +20,7 @@ describe "training convergence" do
     net.add_layer(:output, 1, SHAInet.sigmoid)
     net.fully_connect
 
-    mse = ->do
+    mse = -> do
       total = 0.0
       data.each do |sample|
         got = net.run(sample[0], stealth: true)
@@ -45,7 +45,7 @@ describe "training convergence" do
     after.should be < before * 0.5
   end
 
-  it "updates weights for a multi-label sigmoid output layer" do
+  it "drives error down for a multi-label sigmoid output layer" do
     rng = Random.new(1234)
     pairs = Array(Array(Array(Float64))).new
     300.times do
@@ -62,32 +62,27 @@ describe "training convergence" do
     net.add_layer(:output, 5, SHAInet.sigmoid)
     net.fully_connect
 
-    weights_before = net.output_layers.first.as(SHAInet::MatrixLayer).weights
-    snapshot = Array(Float64).new
-    weights_before.rows.times do |i|
-      weights_before.cols.times { |j| snapshot << weights_before[i, j] }
+    mse = -> do
+      total = 0.0
+      pairs.each do |sample|
+        got = net.run(sample[0], stealth: true)
+        sample[1].each_with_index { |t, i| total += (got[i] - t) ** 2 }
+      end
+      total / (pairs.size * 5)
     end
+
+    before = mse.call
 
     net.train(
       data: pairs,
       training_type: :adam,
       cost_function: :mse,
-      epochs: 20,
+      epochs: 30,
       error_threshold: -1.0,
       mini_batch_size: 32,
       log_each: 10_000
     )
 
-    weights_after = net.output_layers.first.as(SHAInet::MatrixLayer).weights
-    changed = 0
-    idx = 0
-    weights_after.rows.times do |i|
-      weights_after.cols.times do |j|
-        changed += 1 if (weights_after[i, j] - snapshot[idx]).abs > 1e-9
-        idx += 1
-      end
-    end
-
-    changed.should eq(idx)
+    mse.call.should be < before * 0.7
   end
 end

--- a/spec/training_convergence_spec.cr
+++ b/spec/training_convergence_spec.cr
@@ -5,8 +5,23 @@ require "./spec_helper"
 # updates were never uploaded to the device, and because the per-batch input /
 # expected workspaces were handed back to the shared workspace pool while still
 # in use.
+#
+# The global RNG is seeded in each example because MatrixLayer#random_fill!
+# draws from it, and unseeded weight init would make the convergence
+# thresholds below non-deterministic.
+private def flatten_weights(layer : SHAInet::MatrixLayer) : Array(Float64)
+  w = layer.weights
+  values = Array(Float64).new(w.rows * w.cols)
+  w.rows.times do |i|
+    w.cols.times { |j| values << w[i, j] }
+  end
+  values
+end
+
 describe "training convergence" do
   it "drives XOR error down with adam" do
+    Random::DEFAULT.new_seed(42_u64, 54_u64)
+
     data = [
       [[0.0, 0.0], [0.0]],
       [[1.0, 0.0], [1.0]],
@@ -41,11 +56,12 @@ describe "training convergence" do
       log_each: 10_000
     )
 
-    after = mse.call
-    after.should be < before * 0.5
+    mse.call.should be < before * 0.5
   end
 
   it "drives error down for a multi-label sigmoid output layer" do
+    Random::DEFAULT.new_seed(1234_u64, 5678_u64)
+
     rng = Random.new(1234)
     pairs = Array(Array(Array(Float64))).new
     300.times do
@@ -71,6 +87,10 @@ describe "training convergence" do
       total / (pairs.size * 5)
     end
 
+    output_layer = net.output_layers.first.as(SHAInet::MatrixLayer)
+    hidden_layer = net.hidden_layers.first.as(SHAInet::MatrixLayer)
+    output_before = flatten_weights(output_layer)
+    hidden_before = flatten_weights(hidden_layer)
     before = mse.call
 
     net.train(
@@ -82,6 +102,15 @@ describe "training convergence" do
       mini_batch_size: 32,
       log_each: 10_000
     )
+
+    # The original symptom was weights that never moved at all, so assert that
+    # directly in addition to the error dropping: an error metric can shift for
+    # unrelated reasons, but every trainable weight must have been updated.
+    output_after = flatten_weights(output_layer)
+    hidden_after = flatten_weights(hidden_layer)
+
+    output_after.zip(output_before).count { |a, b| (a - b).abs > 1e-9 }.should eq(output_before.size)
+    hidden_after.zip(hidden_before).count { |a, b| (a - b).abs > 1e-9 }.should eq(hidden_before.size)
 
     mse.call.should be < before * 0.7
   end

--- a/src/shainet/basic/matrix_layer.cr
+++ b/src/shainet/basic/matrix_layer.cr
@@ -455,7 +455,13 @@ module SHAInet
         end
       end
 
-      # Sync back to device
+      # Sync back to device — mark host modified since unsafe_set doesn't set the flag
+      weights.mark_host_modified!
+      biases.mark_host_modified!
+      m_w.mark_host_modified!
+      m_b.mark_host_modified!
+      v_w.mark_host_modified!
+      v_b.mark_host_modified!
       weights.sync_to_device!("adam_update")
       biases.sync_to_device!("adam_update")
       m_w.sync_to_device!("adam_update")

--- a/src/shainet/basic/network_run.cr
+++ b/src/shainet/basic/network_run.cr
@@ -150,6 +150,7 @@ module SHAInet
                 end
               end
             end
+            matrix.mark_host_modified!
             matrix.sync_to_device!("activation_fallback")
           end
         end
@@ -1028,7 +1029,12 @@ module SHAInet
           grad_matrix = output_grad.not_nil!
 
           # Try GPU-accelerated cross-entropy when possible
-          if actual_matrix.is_a?(CudaMatrix) && expected_matrix.is_a?(CudaMatrix) && CUDNN.available?
+          # Only use CUDNN softmax+CE when the output layer has identity activation
+          # (i.e., raw logits). CUDNN applies softmax internally, so if the output
+          # layer already applied sigmoid/other activation, this produces wrong gradients.
+          output_is_raw_logits = output_layer.activation_function == SHAInet.identity ||
+                                 output_layer.activation_function == SHAInet.none
+          if output_is_raw_logits && actual_matrix.is_a?(CudaMatrix) && expected_matrix.is_a?(CudaMatrix) && CUDNN.available?
             begin
               loss_value = 0.0
               if use_label_gpu
@@ -1155,13 +1161,12 @@ module SHAInet
         # Force cleanup of temporary matrices created during forward/backward pass
         # Persistent GPU buffers handle workspace reuse
 
-        # Return workspace matrices used for this sample
-        if input_matrix.is_a?(CudaMatrix) && input_workspace && input_matrix.object_id == input_workspace.object_id
-          CudaMatrix.return_workspace(input_matrix)
-        end
-        if expected_matrix.is_a?(CudaMatrix) && expected_workspace && expected_matrix.object_id == expected_workspace.object_id
-          CudaMatrix.return_workspace(expected_matrix)
-        end
+        # NOTE: @batch_in_ws / @batch_out_ws are owned by the network and reused
+        # for every sample in the batch (and across batches). They must NOT be
+        # returned to the shared workspace pool: get_workspace would hand the
+        # same buffer out as a temporary (e.g. the output layer's forward
+        # scratch, which has the same shape as the expected-output workspace),
+        # zero it and overwrite it mid-sample, corrupting the input/target.
       end
 
       learning_rate = current_learning_rate
@@ -1206,42 +1211,26 @@ module SHAInet
           cols = arr[0].as(Array).size
           mat = CudaMatrix.new(rows, cols)
 
-          flat_slice = Slice(Float64).new(rows * cols) do |idx|
-            r = idx // cols
-            c = idx % cols
-            arr[r].as(Array)[c].as(GenNum).to_f64
+          # Write F32 values to host buffer, then sync to device
+          rows.times do |r|
+            cols.times do |c|
+              mat.raw_data[r * cols + c] = arr[r].as(Array)[c].as(GenNum).to_f32
+            end
           end
-
-          if dptr = mat.device_ptr
-            CUDA.memcpy(
-              dptr.as(Pointer(Void)),
-              flat_slice.to_unsafe.as(Pointer(Void)),
-              (flat_slice.size * 4).to_u64,
-              CUDA::MemcpyKind::HostToDevice
-            )
-            mat.mark_device_dirty!
-          end
-
-          flat_slice.each_with_index { |v, i| mat.raw_data[i] = v.to_f32 }
+          mat.mark_host_modified!
+          mat.sync_to_device!("to_matrix")
 
           mat
         else
           cols = arr.size
           mat = CudaMatrix.new(1, cols)
 
-          flat_slice = Slice(Float64).new(cols) { |i| arr[i].as(GenNum).to_f64 }
-
-          if dptr = mat.device_ptr
-            CUDA.memcpy(
-              dptr.as(Pointer(Void)),
-              flat_slice.to_unsafe.as(Pointer(Void)),
-              (flat_slice.size * 4).to_u64,
-              CUDA::MemcpyKind::HostToDevice
-            )
-            mat.mark_device_dirty!
+          # Write F32 values to host buffer, then sync to device
+          cols.times do |i|
+            mat.raw_data[i] = arr[i].as(GenNum).to_f32
           end
-
-          flat_slice.each_with_index { |v, i| mat.raw_data[i] = v.to_f32 }
+          mat.mark_host_modified!
+          mat.sync_to_device!("to_matrix")
 
           mat
         end
@@ -1648,8 +1637,8 @@ module SHAInet
       end
 
       if grad_matrix.is_a?(CudaMatrix)
+        grad_matrix.as(CudaMatrix).mark_host_modified!
         grad_matrix.as(CudaMatrix).sync_to_device!("cost_grad_cpu")
-        grad_matrix.as(CudaMatrix).mark_device_dirty!
       end
 
       sample_error

--- a/src/shainet/math/cuda_matrix.cr
+++ b/src/shainet/math/cuda_matrix.cr
@@ -911,6 +911,7 @@ module SHAInet
 
         @cols.times { |j| unsafe_set(i, j, unsafe_get(i, j) / row_sum) }
       end
+      mark_host_modified!
       sync_to_device!("softmax_result")
 
       # Mark self as having newer GPU data
@@ -1050,6 +1051,7 @@ module SHAInet
           unsafe_set(i, j, result_val)
         end
       end
+      mark_host_modified!
       sync_to_device!("cudnn_element_mul_result")
       mark_device_dirty!
       self
@@ -1083,6 +1085,7 @@ module SHAInet
           end
         end
       end
+      mark_host_modified!
       sync_to_device!("dropout_result")
       mark_device_dirty!
       self
@@ -1108,6 +1111,7 @@ module SHAInet
           unsafe_set(i, j, Math.tanh(val))
         end
       end
+      mark_host_modified!
       sync_to_device!("tanh_result")
       mark_device_dirty!
       self


### PR DESCRIPTION
## Symptom

Training a feedforward net (`135 -> 64 -> 32 -> 15`, all sigmoid, multi-label) with `-Denable_cuda` produced a completely flat error; the same code converged on CPU.

```
Epoch: 0,   Error: -0.86174,  MSE: 0.049506
Epoch: 200, Error: -0.862413, MSE: 0.049584
Epoch: 400, Error: -0.862413, MSE: 0.049584   <- weights never change
```

## Root causes (four, all GPU-only)

**1. CPU-computed output gradients never reached the device.**
`compute_cost_and_gradient_cpu` writes the cost derivatives with `unsafe_set`, which by design does *not* set `@host_modified`. The following `sync_to_device!` therefore hit its `return unless @host_modified` early return and copied nothing, while `mark_device_dirty!` was called regardless — so `backward` consumed the still-zeroed device buffer. Every gradient was zero.

**2. Adam updates never reached the device.**
`update_weights_adam_gpu` syncs down, computes the update on the host with `unsafe_set`, then syncs back — the same silent no-op. The new weights stayed on the host and were discarded by the next `sync_from_device!`.

**3. The batch workspaces were donated to the shared pool while still in use.**
`process_batch` returned `@batch_in_ws` / `@batch_out_ws` to the workspace pool after every sample, even though the network keeps and reuses them. `get_workspace` then handed the same buffer back out as a temporary — the output layer's forward scratch has the same shape as the expected-output workspace — zeroed it and overwrote it mid-sample. This corrupted the target and made the error *diverge* once (1) and (2) were fixed.

**4. CUDNN softmax cross-entropy was used unconditionally.**
Every GPU batch went through `CUDNN.softmax_cross_entropy_loss_and_gradient`, ignoring the requested cost function and the output activation. With a sigmoid output layer the activation is applied twice (sigmoid, then CUDNN's internal softmax); for a single-output layer softmax is identically `1.0`, so the loss was exactly `0.0` and training stopped at epoch 0 on the error threshold. It is now only used when the output layer emits raw logits.

Also fixed, same defect class (`unsafe_set`/`raw_data` write followed by a skipped `sync_to_device!`): `softmax_rows!`, the cuDNN element-mul / dropout / tanh CPU fallbacks, the `run()` activation fallback, and `to_matrix`, which `memcpy`'d a `Slice(Float64)` into an F32 device buffer using `size * 4` bytes (garbage on the device) and then marked it clean, so the correct host values were never uploaded.

## Verification

Single-step probe with fixed weights, one sample — GPU now bit-matches CPU:

```
=== CPU ===                                  === GPU ===
forward: [0.609631]                          forward: [0.609631]
olayer.g_w: -0.049928, -0.04413, -0.056729   olayer.g_w: -0.049928, -0.04413, -0.056729
hidden.g_w: -0.016166, 0.018534, -0.019879   hidden.g_w: -0.016166, 0.018534, -0.019879
olayer.weights: 0.70025, -0.799779, 0.900284 olayer.weights: 0.70025, -0.799779, 0.900284
```

XOR with Adam, GPU (was flat at MSE 0.25):

```
Epoch: 0,    Error: 0.125107, MSE: 0.015652
Epoch: 1000, Error: 0.103422, MSE: 0.010696
Epoch: 1500, Error: 0.059784, MSE: 0.003574
Final outputs: [0.2234, 0.7408, 0.7646, 0.2708]   # targets 0,1,1,0
```

Reported architecture reproduced (135->64->32->15 sigmoid, 1277 samples, sparse multi-label, `mini_batch_size: 32`, Adam), 40 epochs on GPU: **MSE 0.253776 -> 0.022988 (-90.9%)**.

Full suite green both ways: `179 examples, 0 failures` with `-Denable_cuda` (5 pending) and without (26 pending). `crystal tool format --check` and `ameba` clean.

Adds `spec/training_convergence_spec.cr`, which seeds the global RNG (weight init draws from it) and asserts both that the error drops and that every output-layer and hidden-layer weight actually moved. It fails 2/2 examples on master with CUDA enabled and passes on both the CUDA and CPU paths here.

## Behaviour note

Fix (4) changes what the GPU path optimises when you ask for `:mse` with an activated output layer: previously it silently optimised softmax cross-entropy instead. `spec/integration_spec.cr` (iris) was leaning on that — softmax CE happens to be a good objective for 3-class classification, so it reached ~0.6 accuracy in 100 epochs, whereas real MSE lands right on the spec's loose `> 0.2` threshold and flakes. Bumped to 600 epochs, which reaches 0.86–0.98 in about a second.

Full GPU suite run 5x consecutively after the change: `179 examples, 0 failures` each time.

